### PR TITLE
Typo in NTLM namespace calls

### DIFF
--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -215,7 +215,7 @@ module Net
         rescue
           raise ArgumentError
         end
-        chal = NTL::pack_int64le(chal) if chal.is_a?(Integer)
+        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
         keys = gen_keys hash.ljust(21, "\0")
         apply_des(chal, keys).join
       end
@@ -223,7 +223,7 @@ module Net
       def ntlm_response(arg)
         hash = arg[:ntlm_hash]
         chal = arg[:challenge]
-        chal = NTL::pack_int64le(chal) if chal.is_a?(Integer)
+        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
         keys = gen_keys hash.ljust(21, "\0")
         apply_des(chal, keys).join
       end
@@ -236,7 +236,7 @@ module Net
         rescue
           raise ArgumentError
         end
-        chal = NTL::pack_int64le(chal) if chal.is_a?(Integer)
+        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
 
         if opt[:client_challenge]
           cc  = opt[:client_challenge]


### PR DESCRIPTION
Several methods are not called properly due
to a typo in the NTLM namespace. This can cause
several methods to fail
