### PR TITLE
Initial go at an NTLM Client that will do session signing/sealing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,11 @@ task :coverage do
   Rake::Task["spec"].execute
 end
 
+desc "Open a Pry console for this library"
+task :console do
+  require 'pry'
+  require 'net/ntlm'
+  ARGV.clear
+  Pry.start
+end
+

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -57,11 +57,9 @@ require 'net/ntlm/message/type1'
 require 'net/ntlm/message/type2'
 require 'net/ntlm/message/type3'
 
-
 require 'net/ntlm/encode_util'
 
-
-
+require 'net/ntlm/client'
 
 module Net
   module NTLM

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -135,7 +135,7 @@ module Net
       # @option opt :unicode (false) Unicode encode the domain
       def ntlmv2_hash(user, password, target, opt={})
         ntlmhash = ntlm_hash(password, opt)
-        userdomain = (user + target).upcase
+        userdomain = user.upcase + target
         unless opt[:unicode]
           userdomain = EncodeUtil.encode_utf16le(userdomain)
         end

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -25,6 +25,7 @@ module Net
 
       def init_context(resp = nil)
         if resp.nil?
+          clear_state!
           type1_message
         else
           type3_message resp
@@ -80,6 +81,12 @@ module Net
 
       private
 
+
+      def clear_state!
+        (self.instance_variables - [:@username, :@password, :@domain, :@workstation, :@flags]).each do |v|
+          self.instance_variable_set v, nil
+        end
+      end
 
       def type1_message
         type1 = Message::Type1.new

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -1,0 +1,142 @@
+module Net
+  module NTLM
+    class Client
+
+      VERSION_MAGIC = "\x01\x00\x00\x00"
+
+      attr_reader :tokens
+
+      def initialize(user, pass, opts = {})
+        @user         = user
+        @pass         = pass
+        @domain       = ""
+        @workstation  = Socket.gethostname
+        @tokens = {t1: nil, t2: nil, t3: nil}
+        @ntlmv2_user_session_key = nil
+      end
+
+      def init_context(base64_resp = nil)
+        if base64_resp.nil?
+          type1_message
+        else
+          type3_message base64_resp
+        end
+      end
+
+      def sign_message(message, sequence: self.sequence)
+        presig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, sign_key, "#{sequence}#{message}")
+        "#{VERSION_MAGIC}#{presig}#{sequence}"
+      end
+
+      def seal_message(message)
+        seq = sequence
+        emessage = cipher.update(message)
+        emessage << cipher.final
+        signature = sign_message message, sequence: seq
+        "#{emessage}#{signature}"
+      end
+
+      def cipher
+        @cipher ||= begin
+          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+          rc4.encrypt
+          rc4.key = ntlmv2_user_session_key
+        end
+      end
+
+
+      private
+
+
+      def sequence
+        [raw_sequence].pack("V*")
+      end
+
+      def raw_sequence
+        if defined? @raw_sequence
+          @raw_sequence += 1
+        else
+          @raw_sequence = 0
+        end
+      end
+
+      def type1_message
+        Message::Type1.new
+      end
+
+      def type3_message(base64_resp)
+        response Net::NTLM::Message.decode64(base64_resp)
+      end
+
+      def ntlmv2_user_session_key
+        @ntlmv2_user_session_key
+      end
+
+      def signing_key
+        ntlmv2_user_session_key
+      end
+
+      def client_challenge
+        @client_challenge ||= Net::NTLM::pack_int64le rand(Net::NTLM::MAX64)
+      end
+
+      def timestamp
+        @timestamp ||= Time.now.to_i
+      end
+
+      def response(type2)
+        opt = {client_challenge: client_challenge}
+
+        if type2.has_flag?(:OEM)
+          user        = NTLM::EncodeUtil.decode_utf16le(@user)
+          pass        = NTLM::EncodeUtil.decode_utf16le(@pass)
+          @pass       = nil
+          workstation = NTLM::EncodeUtil.decode_utf16le(@workstation)
+          domain      = NTLM::EncodeUtil.decode_utf16le(@domain)
+          opt[:unicode] = false
+        else
+          user        = NTLM::EncodeUtil.encode_utf16le(@user)
+          pass        = NTLM::EncodeUtil.encode_utf16le(@pass)
+          @pass       = nil
+          workstation = NTLM::EncodeUtil.encode_utf16le(@workstation)
+          domain      = NTLM::EncodeUtil.encode_utf16le(@domain)
+          opt[:unicode] = true
+        end
+
+        target_info = type2.target_info
+        challenge   = type2[:challenge].serialize
+
+        @ntlmv2_hash = NTLM::ntlmv2_hash(user, pass, domain, opt)
+
+        blob = NTLM.ntlmv2_response_blob(timestamp, client_challenge, target_info)
+        calculate_user_session_key blob, challenge
+
+        ar = {
+          :ntlmv2_hash      => @ntlmv2_hash,
+          :challenge        => challenge,
+          :target_info      => target_info,
+          :timestamp        => timestamp,
+          :client_challenge => client_challenge,
+          :blob             => blob
+        }
+
+        type3_opts = {
+          lm_response:    NTLM::lmv2_response(ar, opt),
+          ntlm_response:  NTLM::ntlmv2_response(ar, opt),
+          domain:         domain,
+          user:           user,
+          workstation:    workstation,
+          flag:           type2.flag
+        }
+        Message::Type3.create type3_opts
+      end
+
+      def calculate_user_session_key(blob, challenge)
+        key = @ntlmv2_hash
+        tkey = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, challenge + blob)
+        @ntlmv2_user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, tkey)
+      end
+
+    end
+  end
+end

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -8,16 +8,19 @@ module Net
       SERVER_TO_CLIENT_SIGNING = "session key to server-to-client signing key magic constant\0"
       CLIENT_TO_SERVER_SEALING = "session key to client-to-server sealing key magic constant\0"
       SERVER_TO_CLIENT_SEALING = "session key to server-to-client sealing key magic constant\0"
+      DEFAULT_FLAGS = NTLM::FLAGS[:UNICODE] | NTLM::FLAGS[:OEM] |
+        NTLM::FLAGS[:SIGN]   | NTLM::FLAGS[:SEAL]         | NTLM::FLAGS[:REQUEST_TARGET] |
+        NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
+        NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:NEG_KEY_EXCH] | NTLM::FLAGS[:KEY56]
 
-      attr_reader :tokens
+      attr_reader :flags
 
-      def initialize(user, pass, opts = {})
-        @user         = user
-        @pass         = pass
-        @domain       = ""
-        @workstation  = Socket.gethostname
-        @tokens = {t1: nil, t2: nil, t3: nil}
-        @user_session_key = nil
+      def initialize(username, password, opts = {})
+        @username     = username
+        @password     = password
+        @domain       = opts[:domain] || ""
+        @workstation  = opts[:workstation] || nil
+        @flags        = opts[:flags] || DEFAULT_FLAGS
       end
 
       def init_context(resp = nil)
@@ -54,26 +57,8 @@ module Net
         "#{VERSION_MAGIC}#{enc}#{seq}" == signature
       end
 
-      def client_cipher
-        @client_cipher ||= begin
-          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
-          rc4.encrypt
-          rc4.key = client_to_server_seal_key
-          rc4
-        end
-      end
-
-      def server_cipher
-        @server_cipher ||= begin
-          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
-          rc4.decrypt
-          rc4.key = server_to_client_seal_key
-          rc4
-        end
-      end
-
       def user_session_key
-        @user_session_key
+        @user_session_key ||=  nil
       end
 
       def master_key
@@ -82,6 +67,48 @@ module Net
 
       def sequence
         [raw_sequence].pack("V*")
+      end
+
+
+      private
+
+
+      def type1_message
+        type1 = Message::Type1.new
+        type1[:flag].value = flags
+        type1.domain = @domain if @domain
+        type1.workstation = @workstation if @workstation
+        type1
+      end
+
+      def type2_message=(message)
+        @type2_message = Net::NTLM::Message.decode64(message)
+      end
+
+      def type2_message
+        @type2_message
+      end
+
+      def type3_message(resp)
+        self.type2_message = resp
+        calculate_user_session_key!
+        type3_opts = {
+          lm_response:    lmv2_resp,
+          ntlm_response:  ntlmv2_resp,
+          domain:         @domain,
+          user:           username,
+          workstation:    @workstation,
+          flag:           (type2_message.flag & flags)
+        }
+        t3 = Message::Type3.create type3_opts
+        t3.enable(:session_key)
+        rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+        rc4.encrypt
+        rc4.key = user_session_key
+        sk = rc4.update master_key
+        sk << rc4.final
+        t3.session_key = sk
+        t3
       end
 
       def client_to_server_sign_key
@@ -108,9 +135,23 @@ module Net
         end
       end
 
+      def client_cipher
+        @client_cipher ||= begin
+          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+          rc4.encrypt
+          rc4.key = client_to_server_seal_key
+          rc4
+        end
+      end
 
-      private
-
+      def server_cipher
+        @server_cipher ||= begin
+          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+          rc4.decrypt
+          rc4.key = server_to_client_seal_key
+          rc4
+        end
+      end
 
       def raw_sequence
         if defined? @raw_sequence
@@ -120,26 +161,16 @@ module Net
         end
       end
 
-      def type1_message
-        type1 = Message::Type1.new
-        type1[:flag].value = Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:OEM] |
-          Net::NTLM::FLAGS[:SIGN] | Net::NTLM::FLAGS[:SEAL] |
-          Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM] |
-          Net::NTLM::FLAGS[:ALWAYS_SIGN] | Net::NTLM::FLAGS[:NTLM2_KEY] |
-          Net::NTLM::FLAGS[:KEY128] | Net::NTLM::FLAGS[:NEG_KEY_EXCH] | Net::NTLM::FLAGS[:KEY56]
-        type1
-      end
-
-      def type3_message(resp)
-        response Net::NTLM::Message.decode64(resp)
-      end
-
       def signing_key
         session_key
       end
 
       def client_challenge
-        @client_challenge ||= Net::NTLM::pack_int64le rand(Net::NTLM::MAX64)
+        @client_challenge ||= Net::NTLM.pack_int64le rand(Net::NTLM::MAX64)
+      end
+
+      def server_challenge
+        @server_challenge ||= type2_message[:challenge].serialize
       end
 
       def timestamp
@@ -147,76 +178,62 @@ module Net
         @timestamp ||= 10000000 * (Time.now.to_i + TIME_OFFSET)
       end
 
-      def response(type2)
-        opt = {client_challenge: client_challenge}
+      def use_oem_strings?
+        type2_message.has_flag? :OEM
+      end
 
-        if type2.has_flag?(:OEM)
-          user        = NTLM::EncodeUtil.decode_utf16le(@user)
-          pass        = NTLM::EncodeUtil.decode_utf16le(@pass)
-          @pass       = nil
-          workstation = NTLM::EncodeUtil.decode_utf16le(@workstation)
-          domain      = NTLM::EncodeUtil.decode_utf16le(@domain)
-          opt[:unicode] = false
+      def username
+        oem_or_unicode_str @username
+      end
+
+      def password
+        oem_or_unicode_str @password
+      end
+
+      def workstation
+        oem_or_unicode_str @workstation
+      end
+
+      def domain
+        oem_or_unicode_str @domain
+      end
+
+      def oem_or_unicode_str(str)
+        if use_oem_strings?
+          NTLM::EncodeUtil.decode_utf16le str
         else
-          user        = NTLM::EncodeUtil.encode_utf16le(@user)
-          pass        = NTLM::EncodeUtil.encode_utf16le(@pass)
-          @pass       = nil
-          workstation = NTLM::EncodeUtil.encode_utf16le(@workstation)
-          domain      = NTLM::EncodeUtil.encode_utf16le(@domain)
-          opt[:unicode] = true
+          NTLM::EncodeUtil.encode_utf16le str
         end
-
-        target_info = type2.target_info
-        challenge   = type2[:challenge].serialize
-
-        @ntlmv2_hash = NTLM::ntlmv2_hash(user, pass, domain, opt)
-
-        blob = pack_the_blob timestamp, client_challenge, target_info
-
-        calculate_user_session_key blob, challenge
-
-        ar = {
-          :ntlmv2_hash      => @ntlmv2_hash,
-          :challenge        => challenge,
-          :target_info      => target_info,
-          :timestamp        => timestamp,
-          :client_challenge => client_challenge,
-          :blob             => blob
-        }
-
-        type3_opts = {
-          lm_response:    NTLM::lmv2_response(ar, opt),
-          ntlm_response:  NTLM::ntlmv2_response(ar, opt),
-          domain:         domain,
-          user:           user,
-          workstation:    workstation,
-          flag:           type2.flag
-        }
-        t3 = Message::Type3.create type3_opts
-
-        t3.enable(:session_key)
-
-        rc4 = OpenSSL::Cipher::Cipher.new("rc4")
-        rc4.encrypt
-        rc4.key = user_session_key
-        sk = rc4.update master_key
-        sk << rc4.final
-        t3.session_key = sk
-        t3
       end
 
-      def calculate_user_session_key(blob, challenge)
-        key = @ntlmv2_hash
-        tkey = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, challenge + blob)
-        @user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, tkey)
+      def ntlmv2_hash
+        @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain, {client_challenge: client_challenge, unicode: !use_oem_strings?})
       end
 
-      def pack_the_blob(timestamp, client_challenge, target_info)
-        blob = Blob.new
-        blob.timestamp = timestamp
-        blob.challenge = client_challenge
-        blob.target_info = target_info
-        blob.serialize
+      def calculate_user_session_key!
+        @user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, nt_proof_str)
+      end
+
+      def lmv2_resp
+        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + client_challenge) + client_challenge
+      end
+
+      def ntlmv2_resp
+        nt_proof_str + blob
+      end
+
+      def nt_proof_str
+        @nt_proof_str ||= OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + blob)
+      end
+
+      def blob
+        @blob ||= begin
+          b = Blob.new
+          b.timestamp = timestamp
+          b.challenge = client_challenge
+          b.target_info = type2_message.target_info
+          b.serialize
+        end
       end
 
     end

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -11,7 +11,7 @@ module Net
       DEFAULT_FLAGS = NTLM::FLAGS[:UNICODE] | NTLM::FLAGS[:OEM] |
         NTLM::FLAGS[:SIGN]   | NTLM::FLAGS[:SEAL]         | NTLM::FLAGS[:REQUEST_TARGET] |
         NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
-        NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:NEG_KEY_EXCH] | NTLM::FLAGS[:KEY56]
+        NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:KEY_EXCHANGE] | NTLM::FLAGS[:KEY56]
 
       attr_reader :flags
 
@@ -189,7 +189,7 @@ module Net
       end
 
       def negotiate_key_exchange?
-        type2_message.has_flag? :NEG_KEY_EXCH
+        type2_message.has_flag? :KEY_EXCHANGE
       end
 
       def username

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -7,15 +7,7 @@ module Net
         NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
         NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:KEY_EXCHANGE] | NTLM::FLAGS[:KEY56]
 
-      attr_reader :username
-
-      attr_reader :password
-
-      attr_reader :domain
-
-      attr_reader :workstation
-
-      attr_reader :flags
+      attr_reader :username, :password, :domain, :workstation, :flags
 
       # @note All string parameters should be encoded in UTF-8. The proper
       #   final encoding for placing in the various {Message messages} will be

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -2,18 +2,12 @@ module Net
   module NTLM
     class Client
 
-      VERSION_MAGIC = "\x01\x00\x00\x00"
-      TIME_OFFSET   = 11644473600
-      CLIENT_TO_SERVER_SIGNING = "session key to client-to-server signing key magic constant\0"
-      SERVER_TO_CLIENT_SIGNING = "session key to server-to-client signing key magic constant\0"
-      CLIENT_TO_SERVER_SEALING = "session key to client-to-server sealing key magic constant\0"
-      SERVER_TO_CLIENT_SEALING = "session key to server-to-client sealing key magic constant\0"
       DEFAULT_FLAGS = NTLM::FLAGS[:UNICODE] | NTLM::FLAGS[:OEM] |
         NTLM::FLAGS[:SIGN]   | NTLM::FLAGS[:SEAL]         | NTLM::FLAGS[:REQUEST_TARGET] |
         NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
         NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:KEY_EXCHANGE] | NTLM::FLAGS[:KEY56]
 
-      attr_reader :flags
+      attr_reader :username, :password, :domain, :workstation, :flags
 
       def initialize(username, password, opts = {})
         @username     = username
@@ -25,234 +19,32 @@ module Net
 
       def init_context(resp = nil)
         if resp.nil?
-          clear_state!
+          @session = nil
           type1_message
         else
-          type3_message resp
+          @session = Client::Session.new(self, Net::NTLM::Message.decode64(resp))
+          @session.authenticate!
         end
       end
 
-      def sign_message(message)
-        seq = self.sequence
-        sig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, client_to_server_sign_key, "#{seq}#{message}")[0..7]
-        if negotiate_key_exchange?
-          sig = client_cipher.update sig
-          sig << client_cipher.final
-        end
-        "#{VERSION_MAGIC}#{sig}#{seq}"
-      end
-
-      def seal_message(message)
-        emessage = client_cipher.update(message)
-        emessage + client_cipher.final
-      end
-
-      def unseal_message(emessage)
-        message = server_cipher.update(emessage)
-        message + server_cipher.final
-      end
-
-      def verify_signature(signature, message)
-        seq = signature[-4..-1]
-        presig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, server_to_client_sign_key, "#{seq}#{message}")
-        enc = server_cipher.update presig[0..7]
-        enc << server_cipher.final
-        "#{VERSION_MAGIC}#{enc}#{seq}" == signature
-      end
-
-      def user_session_key
-        @user_session_key ||=  nil
-      end
-
-      def master_key
-        @master_key ||= begin
-          if negotiate_key_exchange?
-            OpenSSL::Cipher.new("rc4").random_key
-          else
-            user_session_key
-          end
-        end
-      end
-
-      def sequence
-        [raw_sequence].pack("V*")
+      def session
+        @session
       end
 
 
       private
 
 
-      def clear_state!
-        (self.instance_variables - [:@username, :@password, :@domain, :@workstation, :@flags]).each do |v|
-          self.instance_variable_set v, nil
-        end
-      end
-
       def type1_message
         type1 = Message::Type1.new
         type1[:flag].value = flags
-        type1.domain = @domain if @domain
-        type1.workstation = @workstation if @workstation
+        type1.domain = domain if domain
+        type1.workstation = workstation if workstation
         type1
-      end
-
-      def type2_message=(message)
-        @type2_message = Net::NTLM::Message.decode64(message)
-      end
-
-      def type2_message
-        @type2_message
-      end
-
-      def type3_message(resp)
-        self.type2_message = resp
-        calculate_user_session_key!
-        type3_opts = {
-          lm_response:    lmv2_resp,
-          ntlm_response:  ntlmv2_resp,
-          domain:         @domain,
-          user:           username,
-          workstation:    @workstation,
-          flag:           (type2_message.flag & flags)
-        }
-        t3 = Message::Type3.create type3_opts
-        if negotiate_key_exchange?
-          t3.enable(:session_key)
-          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
-          rc4.encrypt
-          rc4.key = user_session_key
-          sk = rc4.update master_key
-          sk << rc4.final
-          t3.session_key = sk
-        end
-        t3
-      end
-
-      def client_to_server_sign_key
-        @client_to_server_sign_key ||= begin
-          OpenSSL::Digest::MD5.digest "#{master_key}#{CLIENT_TO_SERVER_SIGNING}"
-        end
-      end
-
-      def server_to_client_sign_key
-        @server_to_client_sign_key ||= begin
-          OpenSSL::Digest::MD5.digest "#{master_key}#{SERVER_TO_CLIENT_SIGNING}"
-        end
-      end
-
-      def client_to_server_seal_key
-        @client_to_server_seal_key ||= begin
-          OpenSSL::Digest::MD5.digest "#{master_key}#{CLIENT_TO_SERVER_SEALING}"
-        end
-      end
-
-      def server_to_client_seal_key
-        @server_to_client_seal_key ||= begin
-          OpenSSL::Digest::MD5.digest "#{master_key}#{SERVER_TO_CLIENT_SEALING}"
-        end
-      end
-
-      def client_cipher
-        @client_cipher ||= begin
-          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
-          rc4.encrypt
-          rc4.key = client_to_server_seal_key
-          rc4
-        end
-      end
-
-      def server_cipher
-        @server_cipher ||= begin
-          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
-          rc4.decrypt
-          rc4.key = server_to_client_seal_key
-          rc4
-        end
-      end
-
-      def raw_sequence
-        if defined? @raw_sequence
-          @raw_sequence += 1
-        else
-          @raw_sequence = 0
-        end
-      end
-
-      def client_challenge
-        @client_challenge ||= Net::NTLM.pack_int64le rand(Net::NTLM::MAX64)
-      end
-
-      def server_challenge
-        @server_challenge ||= type2_message[:challenge].serialize
-      end
-
-      def timestamp
-        # epoch -> milsec from Jan 1, 1601
-        @timestamp ||= 10000000 * (Time.now.to_i + TIME_OFFSET)
-      end
-
-      def use_oem_strings?
-        type2_message.has_flag? :OEM
-      end
-
-      def negotiate_key_exchange?
-        type2_message.has_flag? :KEY_EXCHANGE
-      end
-
-      def username
-        oem_or_unicode_str @username
-      end
-
-      def password
-        oem_or_unicode_str @password
-      end
-
-      def workstation
-        oem_or_unicode_str @workstation
-      end
-
-      def domain
-        oem_or_unicode_str @domain
-      end
-
-      def oem_or_unicode_str(str)
-        if use_oem_strings?
-          NTLM::EncodeUtil.decode_utf16le str
-        else
-          NTLM::EncodeUtil.encode_utf16le str
-        end
-      end
-
-      def ntlmv2_hash
-        @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain, {client_challenge: client_challenge, unicode: !use_oem_strings?})
-      end
-
-      def calculate_user_session_key!
-        @user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, nt_proof_str)
-      end
-
-      def lmv2_resp
-        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + client_challenge) + client_challenge
-      end
-
-      def ntlmv2_resp
-        nt_proof_str + blob
-      end
-
-      def nt_proof_str
-        @nt_proof_str ||= OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + blob)
-      end
-
-      def blob
-        @blob ||= begin
-          b = Blob.new
-          b.timestamp = timestamp
-          b.challenge = client_challenge
-          b.target_info = type2_message.target_info
-          b.serialize
-        end
       end
 
     end
   end
 end
+
+require "net/ntlm/client/session"

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -1,0 +1,216 @@
+module Net
+  module NTLM
+    class Client::Session
+
+      VERSION_MAGIC = "\x01\x00\x00\x00"
+      TIME_OFFSET   = 11644473600
+      MAX64         = 0xffffffffffffffff
+      CLIENT_TO_SERVER_SIGNING = "session key to client-to-server signing key magic constant\0"
+      SERVER_TO_CLIENT_SIGNING = "session key to server-to-client signing key magic constant\0"
+      CLIENT_TO_SERVER_SEALING = "session key to client-to-server sealing key magic constant\0"
+      SERVER_TO_CLIENT_SEALING = "session key to server-to-client sealing key magic constant\0"
+
+      attr_reader :client, :challenge_message
+
+      # @param client [Net::NTLM::Client] the client instance
+      # @param challenge_message [Net::NTLM::Message::Type2] server message
+      def initialize(client, challenge_message)
+        @client = client
+        @challenge_message = challenge_message
+      end
+
+      # Generate an NTLMv2 AUTHENTICATE_MESSAGE
+      # @see http://msdn.microsoft.com/en-us/library/cc236643.aspx
+      def authenticate!
+        calculate_user_session_key!
+        type3_opts = {
+          lm_response:    lmv2_resp,
+          ntlm_response:  ntlmv2_resp,
+          domain:         client.domain,
+          user:           username,
+          workstation:    client.workstation,
+          flag:           (challenge_message.flag & client.flags)
+        }
+        t3 = Message::Type3.create type3_opts
+        if negotiate_key_exchange?
+          t3.enable(:session_key)
+          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+          rc4.encrypt
+          rc4.key = user_session_key
+          sk = rc4.update master_key
+          sk << rc4.final
+          t3.session_key = sk
+        end
+        t3
+      end
+
+      def sign_message(message)
+        seq = self.sequence
+        sig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, client_sign_key, "#{seq}#{message}")[0..7]
+        if negotiate_key_exchange?
+          sig = client_cipher.update sig
+          sig << client_cipher.final
+        end
+        "#{VERSION_MAGIC}#{sig}#{seq}"
+      end
+
+      def seal_message(message)
+        emessage = client_cipher.update(message)
+        emessage + client_cipher.final
+      end
+
+      def unseal_message(emessage)
+        message = server_cipher.update(emessage)
+        message + server_cipher.final
+      end
+
+      def verify_signature(signature, message)
+        seq = signature[-4..-1]
+        presig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, server_sign_key, "#{seq}#{message}")
+        enc = server_cipher.update presig[0..7]
+        enc << server_cipher.final
+        "#{VERSION_MAGIC}#{enc}#{seq}" == signature
+      end
+
+      def user_session_key
+        @user_session_key ||=  nil
+      end
+
+      def master_key
+        @master_key ||= begin
+                          if negotiate_key_exchange?
+                            OpenSSL::Cipher.new("rc4").random_key
+                          else
+                            user_session_key
+                          end
+                        end
+      end
+
+      def sequence
+        [raw_sequence].pack("V*")
+      end
+
+      def client_sign_key
+        @client_sign_key ||= OpenSSL::Digest::MD5.digest "#{master_key}#{CLIENT_TO_SERVER_SIGNING}"
+      end
+
+      def server_sign_key
+        @server_sign_key ||= OpenSSL::Digest::MD5.digest "#{master_key}#{SERVER_TO_CLIENT_SIGNING}"
+      end
+
+      def client_seal_key
+        @client_seal_key ||= OpenSSL::Digest::MD5.digest "#{master_key}#{CLIENT_TO_SERVER_SEALING}"
+      end
+
+      def server_seal_key
+        @server_seal_key ||= OpenSSL::Digest::MD5.digest "#{master_key}#{SERVER_TO_CLIENT_SEALING}"
+      end
+
+      def client_cipher
+        @client_cipher ||=
+          begin
+            rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+            rc4.encrypt
+            rc4.key = client_seal_key
+            rc4
+          end
+      end
+
+      def server_cipher
+        @server_cipher ||=
+          begin
+            rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+            rc4.decrypt
+            rc4.key = server_seal_key
+            rc4
+          end
+      end
+
+      def raw_sequence
+        if defined? @raw_sequence
+          @raw_sequence += 1
+        else
+          @raw_sequence = 0
+        end
+      end
+
+      def client_challenge
+        @client_challenge ||= [rand(MAX64)].pack("Q")
+      end
+
+      def server_challenge
+        @server_challenge ||= challenge_message[:challenge].serialize
+      end
+
+      # epoch -> milsec from Jan 1, 1601
+      # @see http://support.microsoft.com/kb/188768
+      def timestamp
+        @timestamp ||= 10000000 * (Time.now.to_i + TIME_OFFSET)
+      end
+
+      def use_oem_strings?
+        challenge_message.has_flag? :OEM
+      end
+
+      def negotiate_key_exchange?
+        challenge_message.has_flag? :KEY_EXCHANGE
+      end
+
+      def username
+        oem_or_unicode_str client.username
+      end
+
+      def password
+        oem_or_unicode_str client.password
+      end
+
+      def workstation
+        oem_or_unicode_str client.workstation
+      end
+
+      def domain
+        oem_or_unicode_str client.domain
+      end
+
+      def oem_or_unicode_str(str)
+        if use_oem_strings?
+          NTLM::EncodeUtil.decode_utf16le str
+        else
+          NTLM::EncodeUtil.encode_utf16le str
+        end
+      end
+
+      def ntlmv2_hash
+        @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain, {client_challenge: client_challenge, unicode: !use_oem_strings?})
+      end
+
+      def calculate_user_session_key!
+        @user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, nt_proof_str)
+      end
+
+      def lmv2_resp
+        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + client_challenge) + client_challenge
+      end
+
+      def ntlmv2_resp
+        nt_proof_str + blob
+      end
+
+      def nt_proof_str
+        @nt_proof_str ||= OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + blob)
+      end
+
+      def blob
+        @blob ||=
+          begin
+            b = Blob.new
+            b.timestamp = timestamp
+            b.challenge = client_challenge
+            b.target_info = challenge_message.target_info
+            b.serialize
+          end
+      end
+
+    end
+  end
+end

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -24,12 +24,12 @@ module Net
       def authenticate!
         calculate_user_session_key!
         type3_opts = {
-          lm_response:    lmv2_resp,
-          ntlm_response:  ntlmv2_resp,
-          domain:         client.domain,
-          user:           username,
-          workstation:    client.workstation,
-          flag:           (challenge_message.flag & client.flags)
+          :lm_response   => lmv2_resp,
+          :ntlm_response => ntlmv2_resp,
+          :domain        => client.domain,
+          :user          => username,
+          :workstation   => client.workstation,
+          :flag          => (challenge_message.flag & client.flags)
         }
         t3 = Message::Type3.create type3_opts
         if negotiate_key_exchange?
@@ -187,7 +187,7 @@ module Net
       end
 
       def ntlmv2_hash
-        @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain, {client_challenge: client_challenge, unicode: !use_oem_strings?})
+        @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain, {:client_challenge => client_challenge, :unicode => !use_oem_strings?})
       end
 
       def calculate_user_session_key!

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -141,7 +141,7 @@ module Net
       end
 
       def client_challenge
-        @client_challenge ||= [rand(MAX64)].pack("Q")
+        @client_challenge ||= NTLM.pack_int64le(rand(MAX64))
       end
 
       def server_challenge

--- a/lib/net/ntlm/message.rb
+++ b/lib/net/ntlm/message.rb
@@ -20,8 +20,8 @@ module NTLM
       :LOCAL_CALL           => 0x00004000,
       :ALWAYS_SIGN          => 0x00008000,
       :TARGET_TYPE_DOMAIN   => 0x00010000,
-      :TARGET_INFO          => 0x00800000,
       :NTLM2_KEY            => 0x00080000,
+      :TARGET_INFO          => 0x00800000,
       :KEY128               => 0x20000000,
       :KEY_EXCHANGE         => 0x40000000,
       :KEY56                => 0x80000000

--- a/lib/net/ntlm/message/type1.rb
+++ b/lib/net/ntlm/message/type1.rb
@@ -16,5 +16,3 @@ module Net
     end
   end
 end
-
-

--- a/lib/net/ntlm/message/type3.rb
+++ b/lib/net/ntlm/message/type3.rb
@@ -39,7 +39,7 @@ module Net
 
             if arg[:session_key]
               t.enable(:session_key)
-              t.session_key = arg[session_key]
+              t.session_key = arg[:session_key]
             end
 
             if arg[:flag]

--- a/rubyntlm.gemspec
+++ b/rubyntlm.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
+  s.add_development_dependency "pry"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 2.11"
   s.add_development_dependency "simplecov"

--- a/spec/lib/net/ntlm/client/session_spec.rb
+++ b/spec/lib/net/ntlm/client/session_spec.rb
@@ -4,33 +4,64 @@ describe Net::NTLM::Client::Session do
   let(:t2_challenge) { Net::NTLM::Message.decode64 "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA==" }
   let(:inst) { Net::NTLM::Client::Session.new(nil, t2_challenge) }
   let(:user_session_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
+  let(:client_sign_key) {["f7f97a82ec390f9c903dac4f6aceb132"].pack("H*")}
+  let(:client_seal_key) {["6f0d99535033951cbe499cd1914fe9ee"].pack("H*")}
+  let(:server_sign_key) {["f7f97a82ec390f9c903dac4f6aceb132"].pack("H*")}
+  let(:server_seal_key) {["6f0d99535033951cbe499cd1914fe9ee"].pack("H*")}
 
   describe "#sign_message" do
-    let(:client_sign_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
-    let(:client_seal_key) {["51eb7030ed5875e5c33e4501d27edbac"].pack("H*")}
 
     it "signs a message and when KEY_EXCHANGE is true" do
       expect(inst).to receive(:client_sign_key).and_return(client_sign_key)
       expect(inst).to receive(:client_seal_key).and_return(client_seal_key)
       expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
       sm = inst.sign_message("Test Message")
-      str = "\x01\x00\x00\x00\xC2\xE6\t\xFB\x05q\xC1\xC7\x00\x00\x00\x00".force_encoding(Encoding::ASCII_8BIT)
-      expect(sm).to eq(str)
+      str = "01000000b35ccd60c110c52f00000000"
+      expect(sm.unpack("H*")[0]).to eq(str)
     end
 
+  end
+
+  describe "#verify_signature" do
+
+    it "verifies a message signature" do
+      expect(inst).to receive(:server_sign_key).and_return(server_sign_key)
+      expect(inst).to receive(:server_seal_key).and_return(server_seal_key)
+      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
+      sig = "01000000b35ccd60c110c52f00000000"
+      sm = inst.verify_signature([sig].pack("H*"), "Test Message")
+      expect(sm).to be true
+    end
+
+  end
+
+  describe "#seal_message" do
+    it "should seal the message" do
+      expect(inst).to receive(:client_seal_key).and_return(client_seal_key)
+      emsg = inst.seal_message("rubyntlm")
+      expect(emsg.unpack("H*")[0]).to eq("d7389b9604f6274f")
+    end
+  end
+
+  describe "#unseal_message" do
+    it "should unseal the message" do
+      expect(inst).to receive(:server_seal_key).and_return(server_seal_key)
+      msg = inst.unseal_message(["d7389b9604f6274f"].pack("H*"))
+      expect(msg).to eq("rubyntlm")
+    end
   end
 
   describe "#master_key" do
     it "returns a random 16-byte key when negotiate_key_exchange? is true" do
       expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
       expect(inst).not_to receive(:user_session_key)
-      inst.master_key
+      inst.send :master_key
     end
 
     it "returns the user_session_key when negotiate_key_exchange? is false" do
       expect(inst).to receive(:negotiate_key_exchange?).and_return(false)
       expect(inst).to receive(:user_session_key).and_return(user_session_key)
-      inst.master_key
+      inst.send :master_key
     end
   end
 

--- a/spec/lib/net/ntlm/client/session_spec.rb
+++ b/spec/lib/net/ntlm/client/session_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Net::NTLM::Client::Session do
+  let(:t2_challenge) { Net::NTLM::Message.decode64 "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA==" }
+  let(:inst) { Net::NTLM::Client::Session.new(nil, t2_challenge) }
+  let(:user_session_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
+
+  describe "#sign_message" do
+    let(:client_sign_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
+    let(:client_seal_key) {["51eb7030ed5875e5c33e4501d27edbac"].pack("H*")}
+
+    it "signs a message and when KEY_EXCHANGE is true" do
+      expect(inst).to receive(:client_sign_key).and_return(client_sign_key)
+      expect(inst).to receive(:client_seal_key).and_return(client_seal_key)
+      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
+      sm = inst.sign_message("Test Message")
+      str = "\x01\x00\x00\x00\xC2\xE6\t\xFB\x05q\xC1\xC7\x00\x00\x00\x00".force_encoding(Encoding::ASCII_8BIT)
+      expect(sm).to eq(str)
+    end
+
+  end
+
+  describe "#master_key" do
+    it "returns a random 16-byte key when negotiate_key_exchange? is true" do
+      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
+      expect(inst).not_to receive(:user_session_key)
+      inst.master_key
+    end
+
+    it "returns the user_session_key when negotiate_key_exchange? is false" do
+      expect(inst).to receive(:negotiate_key_exchange?).and_return(false)
+      expect(inst).to receive(:user_session_key).and_return(user_session_key)
+      inst.master_key
+    end
+  end
+
+end

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -7,21 +7,21 @@ describe Net::NTLM::Client do
   describe "#init_context" do
 
     it "returns a default Type1 message" do
-      t2 = inst.init_context
-      expect(t2).to be_instance_of Net::NTLM::Message::Type1
-      expect(t2.domain).to eq("")
-      expect(t2.workstation).to eq("testhost")
-      expect(t2.has_flag?(:UNICODE)).to be true
-      expect(t2.has_flag?(:OEM)).to be true
-      expect(t2.has_flag?(:SIGN)).to be true
-      expect(t2.has_flag?(:SEAL)).to be true
-      expect(t2.has_flag?(:REQUEST_TARGET)).to be true
-      expect(t2.has_flag?(:NTLM)).to be true
-      expect(t2.has_flag?(:ALWAYS_SIGN)).to be true
-      expect(t2.has_flag?(:NTLM2_KEY)).to be true
-      expect(t2.has_flag?(:KEY128)).to be true
-      expect(t2.has_flag?(:KEY_EXCHANGE)).to be true
-      expect(t2.has_flag?(:KEY56)).to be true
+      t1 = inst.init_context
+      expect(t1).to be_instance_of Net::NTLM::Message::Type1
+      expect(t1.domain).to eq("")
+      expect(t1.workstation).to eq("testhost")
+      expect(t1).to have_flag(:UNICODE)
+      expect(t1).to have_flag(:OEM)
+      expect(t1).to have_flag(:SIGN)
+      expect(t1).to have_flag(:SEAL)
+      expect(t1).to have_flag(:REQUEST_TARGET)
+      expect(t1).to have_flag(:NTLM)
+      expect(t1).to have_flag(:ALWAYS_SIGN)
+      expect(t1).to have_flag(:NTLM2_KEY)
+      expect(t1).to have_flag(:KEY128)
+      expect(t1).to have_flag(:KEY_EXCHANGE)
+      expect(t1).to have_flag(:KEY56)
     end
 
     it "clears session variable on new init_context" do
@@ -34,21 +34,21 @@ describe Net::NTLM::Client do
     it "returns a Type1 message with custom flags" do
       flags = Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM]
       inst = Net::NTLM::Client.new("test", "test01", :workstation => "testhost", :flags => flags)
-      t2 = inst.init_context
-      expect(t2).to be_instance_of Net::NTLM::Message::Type1
-      expect(t2.domain).to eq("")
-      expect(t2.workstation).to eq("testhost")
-      expect(t2.has_flag?(:UNICODE)).to be true
-      expect(t2.has_flag?(:OEM)).to be false
-      expect(t2.has_flag?(:SIGN)).to be false
-      expect(t2.has_flag?(:SEAL)).to be false
-      expect(t2.has_flag?(:REQUEST_TARGET)).to be true
-      expect(t2.has_flag?(:NTLM)).to be true
-      expect(t2.has_flag?(:ALWAYS_SIGN)).to be false
-      expect(t2.has_flag?(:NTLM2_KEY)).to be false
-      expect(t2.has_flag?(:KEY128)).to be false
-      expect(t2.has_flag?(:KEY_EXCHANGE)).to be false
-      expect(t2.has_flag?(:KEY56)).to be false
+      t1 = inst.init_context
+      expect(t1).to be_instance_of Net::NTLM::Message::Type1
+      expect(t1.domain).to eq("")
+      expect(t1.workstation).to eq("testhost")
+      expect(t1).to have_flag(:UNICODE)
+      expect(t1).not_to have_flag(:OEM)
+      expect(t1).not_to have_flag(:SIGN)
+      expect(t1).not_to have_flag(:SEAL)
+      expect(t1).to have_flag(:REQUEST_TARGET)
+      expect(t1).to have_flag(:NTLM)
+      expect(t1).not_to have_flag(:ALWAYS_SIGN)
+      expect(t1).not_to have_flag(:NTLM2_KEY)
+      expect(t1).not_to have_flag(:KEY128)
+      expect(t1).not_to have_flag(:KEY_EXCHANGE)
+      expect(t1).not_to have_flag(:KEY56)
     end
 
     it "calls authenticate! when we receive a Challenge Message" do

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -20,7 +20,7 @@ describe Net::NTLM::Client do
       expect(t2.has_flag?(:ALWAYS_SIGN)).to be true
       expect(t2.has_flag?(:NTLM2_KEY)).to be true
       expect(t2.has_flag?(:KEY128)).to be true
-      expect(t2.has_flag?(:NEG_KEY_EXCH)).to be true
+      expect(t2.has_flag?(:KEY_EXCHANGE)).to be true
       expect(t2.has_flag?(:KEY56)).to be true
     end
 
@@ -40,7 +40,7 @@ describe Net::NTLM::Client do
       expect(t2.has_flag?(:ALWAYS_SIGN)).to be false
       expect(t2.has_flag?(:NTLM2_KEY)).to be false
       expect(t2.has_flag?(:KEY128)).to be false
-      expect(t2.has_flag?(:NEG_KEY_EXCH)).to be false
+      expect(t2.has_flag?(:KEY_EXCHANGE)).to be false
       expect(t2.has_flag?(:KEY56)).to be false
     end
 
@@ -56,7 +56,7 @@ describe Net::NTLM::Client do
     let(:client_to_server_sign_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
     let(:client_to_server_seal_key) {["51eb7030ed5875e5c33e4501d27edbac"].pack("H*")}
 
-    it "signs a message and when NEG_KEY_EXCH is true" do
+    it "signs a message and when KEY_EXCHANGE is true" do
       expect(inst).to receive(:client_to_server_sign_key).and_return(client_to_server_sign_key)
       expect(inst).to receive(:client_to_server_seal_key).and_return(client_to_server_seal_key)
       expect(inst).to receive(:negotiate_key_exchange?).and_return(true)

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Net::NTLM::Client do
-  let(:inst) { Net::NTLM::Client.new("test", "test01", workstation: "testhost") }
+  let(:inst) { Net::NTLM::Client.new("test", "test01", :workstation => "testhost") }
   let(:user_session_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
 
   describe "#init_context" do
@@ -33,7 +33,7 @@ describe Net::NTLM::Client do
 
     it "returns a Type1 message with custom flags" do
       flags = Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM]
-      inst = Net::NTLM::Client.new("test", "test01", workstation: "testhost", flags: flags)
+      inst = Net::NTLM::Client.new("test", "test01", :workstation => "testhost", :flags => flags)
       t2 = inst.init_context
       expect(t2).to be_instance_of Net::NTLM::Message::Type1
       expect(t2.domain).to eq("")

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -24,15 +24,11 @@ describe Net::NTLM::Client do
       expect(t2.has_flag?(:KEY56)).to be true
     end
 
-    it "clears instance variables on new init_context" do
-      inst.instance_variable_set :@user_session_key, "BADKEY"
-      expect(inst.user_session_key).to eq("BADKEY")
+    it "clears session variable on new init_context" do
+      inst.instance_variable_set :@session, "BADSESSION"
+      expect(inst.session).to eq("BADSESSION")
       inst.init_context
-      expect(inst.user_session_key).to be_nil
-      expect(inst.instance_variable_get(:@username)).to eq("test")
-      expect(inst.instance_variable_get(:@password)).to eq("test01")
-      expect(inst.instance_variable_get(:@workstation)).to eq("testhost")
-      expect(inst.instance_variable_get(:@flags)).to eq(Net::NTLM::Client::DEFAULT_FLAGS)
+      expect(inst.session).to be_nil
     end
 
     it "returns a Type1 message with custom flags" do
@@ -55,41 +51,14 @@ describe Net::NTLM::Client do
       expect(t2.has_flag?(:KEY56)).to be false
     end
 
-     it "returns a Type3 message" do
-       t2_challenge = "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA=="
-       t3 = inst.init_context t2_challenge
-       expect(t3).to be_instance_of Net::NTLM::Message::Type3
-     end
-
-  end
-
-  describe "#sign_message" do
-    let(:client_to_server_sign_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
-    let(:client_to_server_seal_key) {["51eb7030ed5875e5c33e4501d27edbac"].pack("H*")}
-
-    it "signs a message and when KEY_EXCHANGE is true" do
-      expect(inst).to receive(:client_to_server_sign_key).and_return(client_to_server_sign_key)
-      expect(inst).to receive(:client_to_server_seal_key).and_return(client_to_server_seal_key)
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
-      sm = inst.sign_message("Test Message")
-      str = "\x01\x00\x00\x00\xC2\xE6\t\xFB\x05q\xC1\xC7\x00\x00\x00\x00".force_encoding(Encoding::ASCII_8BIT)
-      expect(sm).to eq(str)
+    it "calls authenticate! when we receive a Challenge Message" do
+      t2_challenge = "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA=="
+      session = double("session")
+      expect(session).to receive(:authenticate!)
+      expect(Net::NTLM::Client::Session).to receive(:new).with(inst, instance_of(Net::NTLM::Message::Type2)).and_return(session)
+      inst.init_context t2_challenge
     end
 
-  end
-
-  describe "#master_key" do
-    it "returns a random 16-byte key when negotiate_key_exchange? is true" do
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
-      expect(inst).not_to receive(:user_session_key)
-      inst.master_key
-    end
-
-    it "returns the user_session_key when negotiate_key_exchange? is false" do
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(false)
-      expect(inst).to receive(:user_session_key).and_return(user_session_key)
-      inst.master_key
-    end
   end
 
 end

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Net::NTLM::Client do
+  let(:inst) { Net::NTLM::Client.new("test", "test01", workstation: "testhost") }
+
+  describe "#init_context" do
+
+    it "returns a default Type1 message" do
+      t2 = inst.init_context
+      expect(t2).to be_instance_of Net::NTLM::Message::Type1
+      expect(t2.domain).to eq("")
+      expect(t2.workstation).to eq("testhost")
+      expect(t2.has_flag?(:UNICODE)).to be true
+      expect(t2.has_flag?(:OEM)).to be true
+      expect(t2.has_flag?(:SIGN)).to be true
+      expect(t2.has_flag?(:SEAL)).to be true
+      expect(t2.has_flag?(:REQUEST_TARGET)).to be true
+      expect(t2.has_flag?(:NTLM)).to be true
+      expect(t2.has_flag?(:ALWAYS_SIGN)).to be true
+      expect(t2.has_flag?(:NTLM2_KEY)).to be true
+      expect(t2.has_flag?(:KEY128)).to be true
+      expect(t2.has_flag?(:NEG_KEY_EXCH)).to be true
+      expect(t2.has_flag?(:KEY56)).to be true
+    end
+
+    it "returns a Type1 message with custom flags" do
+      flags = Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM]
+      inst = Net::NTLM::Client.new("test", "test01", workstation: "testhost", flags: flags)
+      t2 = inst.init_context
+      expect(t2).to be_instance_of Net::NTLM::Message::Type1
+      expect(t2.domain).to eq("")
+      expect(t2.workstation).to eq("testhost")
+      expect(t2.has_flag?(:UNICODE)).to be true
+      expect(t2.has_flag?(:OEM)).to be false
+      expect(t2.has_flag?(:SIGN)).to be false
+      expect(t2.has_flag?(:SEAL)).to be false
+      expect(t2.has_flag?(:REQUEST_TARGET)).to be true
+      expect(t2.has_flag?(:NTLM)).to be true
+      expect(t2.has_flag?(:ALWAYS_SIGN)).to be false
+      expect(t2.has_flag?(:NTLM2_KEY)).to be false
+      expect(t2.has_flag?(:KEY128)).to be false
+      expect(t2.has_flag?(:NEG_KEY_EXCH)).to be false
+      expect(t2.has_flag?(:KEY56)).to be false
+    end
+
+     it "returns a Type3 message" do
+       t2_challenge = "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA=="
+       t3 = inst.init_context t2_challenge
+       expect(t3).to be_instance_of Net::NTLM::Message::Type3
+     end
+
+  end
+
+  describe "#sign_message" do
+    let(:client_to_server_sign_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
+    let(:client_to_server_seal_key) {["51eb7030ed5875e5c33e4501d27edbac"].pack("H*")}
+
+    it "signs a message and when NTLM sealing is active" do
+      expect(inst).to receive(:client_to_server_sign_key).and_return(client_to_server_sign_key)
+      expect(inst).to receive(:client_to_server_seal_key).and_return(client_to_server_seal_key)
+      sm = inst.sign_message("Test Message")
+      str = "\x01\x00\x00\x00\xC2\xE6\t\xFB\x05q\xC1\xC7\x00\x00\x00\x00".force_encoding(Encoding::ASCII_8BIT)
+      expect(sm).to eq(str)
+    end
+  end
+end

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -24,6 +24,17 @@ describe Net::NTLM::Client do
       expect(t2.has_flag?(:KEY56)).to be true
     end
 
+    it "clears instance variables on new init_context" do
+      inst.instance_variable_set :@user_session_key, "BADKEY"
+      expect(inst.user_session_key).to eq("BADKEY")
+      inst.init_context
+      expect(inst.user_session_key).to be_nil
+      expect(inst.instance_variable_get(:@username)).to eq("test")
+      expect(inst.instance_variable_get(:@password)).to eq("test01")
+      expect(inst.instance_variable_get(:@workstation)).to eq("testhost")
+      expect(inst.instance_variable_get(:@flags)).to eq(Net::NTLM::Client::DEFAULT_FLAGS)
+    end
+
     it "returns a Type1 message with custom flags" do
       flags = Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM]
       inst = Net::NTLM::Client.new("test", "test01", workstation: "testhost", flags: flags)

--- a/spec/lib/net/ntlm_spec.rb
+++ b/spec/lib/net/ntlm_spec.rb
@@ -1,11 +1,9 @@
-
-require 'rspec'
-require 'net/ntlm'
+require "spec_helper"
 
 describe Net::NTLM do
   let(:passwd) {"SecREt01"}
   let(:user) {"user"}
-  let(:domain) {"domain"}
+  let(:domain) {"DOMAIN"}
   let(:challenge) {["0123456789abcdef"].pack("H*")}
   let(:client_ch) {["ffffff0011223344"].pack("H*")}
   let(:timestamp) {1055844000}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ end if ENV["COVERAGE"]
 
 require 'rspec'
 require 'net/ntlm'
-require "pry"
 
 # add project lib directory to load path
 spec_pathname = Pathname.new(__FILE__).dirname

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,9 @@ SimpleCov.start do
   add_filter '/vendor/'
 end if ENV["COVERAGE"]
 
-
 require 'rspec'
 require 'net/ntlm'
+require "pry"
 
 # add project lib directory to load path
 spec_pathname = Pathname.new(__FILE__).dirname


### PR DESCRIPTION
There is some duplication between `Net::NTLM` and `Net::NTLM::Client::Session` but it was necessary to decouple some of the processing without effecting how `Net::NTLM` is being used for legacy purposes. Maybe we can rectify some of this in a 2.0 release.

CC: @pmorton This is required in order to get _Negotiate_ session encryption working for **WinRM**.