### PR TITLE
Encode client and domain in oem/unicode in `Client#authenticate!`

### DIFF
--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -9,10 +9,13 @@ module Net
 
       attr_reader :username, :password, :domain, :workstation, :flags
 
+      # @note All string parameters should be encoded in UTF-8. The proper
+      #   final encoding for placing in the various {Message}s will be chosen
+      #   based on negotiation with the server.
       def initialize(username, password, opts = {})
         @username     = username
         @password     = password
-        @domain       = opts[:domain] || ""
+        @domain       = opts[:domain] || nil
         @workstation  = opts[:workstation] || nil
         @flags        = opts[:flags] || DEFAULT_FLAGS
       end

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -7,11 +7,25 @@ module Net
         NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
         NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:KEY_EXCHANGE] | NTLM::FLAGS[:KEY56]
 
-      attr_reader :username, :password, :domain, :workstation, :flags
+      attr_reader :username
+
+      attr_reader :password
+
+      attr_reader :domain
+
+      attr_reader :workstation
+
+      attr_reader :flags
 
       # @note All string parameters should be encoded in UTF-8. The proper
-      #   final encoding for placing in the various {Message}s will be chosen
-      #   based on negotiation with the server.
+      #   final encoding for placing in the various {Message messages} will be
+      #   chosen based on negotiation with the server.
+      #
+      # @param username [String]
+      # @param password [String]
+      # @option opts [String] :domain where we're authenticating to
+      # @option opts [String] :workstation local workstation name
+      # @option opts [Fixnum] :flags (DEFAULT_FLAGS) see Net::NTLM::Message::Type1.flag
       def initialize(username, password, opts = {})
         @username     = username
         @password     = password
@@ -20,6 +34,7 @@ module Net
         @flags        = opts[:flags] || DEFAULT_FLAGS
       end
 
+      # @return [NTLM::Message]
       def init_context(resp = nil)
         if resp.nil?
           @session = nil
@@ -30,19 +45,20 @@ module Net
         end
       end
 
+      # @return [Client::Session]
       def session
         @session
       end
 
-
       private
 
-
+      # @return [Message::Type1]
       def type1_message
         type1 = Message::Type1.new
         type1[:flag].value = flags
         type1.domain = domain if domain
         type1.workstation = workstation if workstation
+
         type1
       end
 

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -21,14 +21,15 @@ module Net
 
       # Generate an NTLMv2 AUTHENTICATE_MESSAGE
       # @see http://msdn.microsoft.com/en-us/library/cc236643.aspx
+      # @return [Net::NTLM::Message::Type3]
       def authenticate!
         calculate_user_session_key!
         type3_opts = {
           :lm_response   => lmv2_resp,
           :ntlm_response => ntlmv2_resp,
-          :domain        => client.domain,
+          :domain        => domain,
           :user          => username,
-          :workstation   => client.workstation,
+          :workstation   => workstation,
           :flag          => (challenge_message.flag & client.flags)
         }
         t3 = Message::Type3.create type3_opts
@@ -151,7 +152,7 @@ module Net
       # epoch -> milsec from Jan 1, 1601
       # @see http://support.microsoft.com/kb/188768
       def timestamp
-        @timestamp ||= 10000000 * (Time.now.to_i + TIME_OFFSET)
+        @timestamp ||= 10_000_000 * (Time.now.to_i + TIME_OFFSET)
       end
 
       def use_oem_strings?
@@ -171,11 +172,11 @@ module Net
       end
 
       def workstation
-        oem_or_unicode_str client.workstation
+        (client.domain ? oem_or_unicode_str(client.workstation) : "")
       end
 
       def domain
-        oem_or_unicode_str client.domain
+        (client.domain ? oem_or_unicode_str(client.domain) : "")
       end
 
       def oem_or_unicode_str(str)


### PR DESCRIPTION
I'm using [my SMB2 implementation](https://github.com/jlee-r7/smb2) to exercise this code.  Type1 messages have to have the domain/workstation encoded as OEM (ascii), so we need to pass them in as either `"binary"` or `"utf-8"` encoding to the `Client` constructor. However, when we build the Type3 message, it has to be in whatever encoding was negotiated, usually Unicode ("utf-16le").

Without this change, passing correct user/pass:
 * domain encoded as ascii-8bit or utf-8 results in `STATUS_LOGON_FAILURE`
 * domain encoded as unicode results in this stack trace:
```
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-16LE
	from /home/egypt/repo/rubyntlm/lib/net/ntlm/message.rb:90:in `serialize'
	from /home/egypt/repo/smb2/lib/smb2/client.rb:72:in `authenticate'
	from (irb):2
	from /home/egypt/.rvm/rubies/ruby-2.1.5/bin/irb:11:in `<main>'
```

After this change, passing domain as ascii-8bit or utf-8 works as expected.

