### PR TITLE
Make the session key available to clients

### DIFF
--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -42,6 +42,10 @@ module Net
         @session
       end
 
+      def session_key
+        @session.exported_session_key
+      end
+
       private
 
       # @return [Message::Type1]

--- a/spec/lib/net/ntlm/client/session_spec.rb
+++ b/spec/lib/net/ntlm/client/session_spec.rb
@@ -51,17 +51,17 @@ describe Net::NTLM::Client::Session do
     end
   end
 
-  describe "#master_key" do
+  describe "#exported_session_key" do
     it "returns a random 16-byte key when negotiate_key_exchange? is true" do
       expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
       expect(inst).not_to receive(:user_session_key)
-      inst.send :master_key
+      inst.exported_session_key
     end
 
     it "returns the user_session_key when negotiate_key_exchange? is false" do
       expect(inst).to receive(:negotiate_key_exchange?).and_return(false)
       expect(inst).to receive(:user_session_key).and_return(user_session_key)
-      inst.send :master_key
+      inst.exported_session_key
     end
   end
 


### PR DESCRIPTION
[[MS-NLMP] 3.1.5.1.2](https://msdn.microsoft.com/en-us/library/cc246772.aspx) uses `ExportedSessionKey` for what this code calling `master_key`.

SMB2 uses `ExportedSessionKey` as the signing key -- [[MS-SMB2] 3.3.5.5.3](https://msdn.microsoft.com/en-us/library/cc246772.aspx).

This pull request changes the name to match the documentation and makes it a public method so I don't have to reach into the object's privates with `send`. (see https://github.com/rapid7/smb2/blob/master/lib/smb2/client.rb#L215-L219)