### PR TITLE
fix NTLM1 auth - NTLM::lm_response(pwd, chal) and NTLM::ntlm_response…

### DIFF
--- a/lib/net/ntlm/message/type2.rb
+++ b/lib/net/ntlm/message/type2.rb
@@ -77,8 +77,10 @@ module Net
             ar = {:ntlm_hash => NTLM::ntlm_hash(pwd, opt), :challenge => chal}
             lm_res, ntlm_res = NTLM::ntlm2_session(ar, opt)
           else
-            lm_res = NTLM::lm_response(pwd, chal)
-            ntlm_res = NTLM::ntlm_response(pwd, chal)
+            ar = {:lm_hash => NTLM::lm_hash(pwd), :challenge => chal}
+            lm_res = NTLM::lm_response(ar)
+            ar = {:ntlm_hash => NTLM::ntlm_hash(pwd, opt), :challenge => chal}
+            ntlm_res = NTLM::ntlm_response(ar)
           end
 
           Type3.create({


### PR DESCRIPTION
Hi,
there is a bug while using NTLM1 => "bad number of arguments" in call of these two functions:

1) NTLM::lm_response(pwd, chal) => NTLM::lm_response({:lm_hash => NTLM::lm_hash(pwd), :challenge => chal}),

2) NTLM::ntlm_response(pwd, chal) => NTLM::ntlm_response({:ntlm_hash => NTLM::ntlm_hash(pwd, opt), :challenge => chal})

Please accepting this pull requst and sorry my changes added to previous one.
These changes was added to my master branch after creating previous pull request ... sorry.