### PR TITLE
fix session.workstation when passing only domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ rvm:
   - rbx-19mode
   - rbx-18mode
   - jruby-19mode
-
+before_install:
+  - gem update bundler

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -172,7 +172,7 @@ module Net
       end
 
       def workstation
-        (client.domain ? oem_or_unicode_str(client.workstation) : "")
+        (client.workstation ? oem_or_unicode_str(client.workstation) : "")
       end
 
       def domain

--- a/lib/net/ntlm/version.rb
+++ b/lib/net/ntlm/version.rb
@@ -4,7 +4,7 @@ module Net
     module VERSION
       MAJOR = 0
       MINOR = 5
-      TINY  = 2
+      TINY  = 3
       STRING = [MAJOR, MINOR, TINY].join('.')
     end
   end


### PR DESCRIPTION
This fixes:
```
C:/Users/MattWrock/AppData/Local/chefdk/gem/ruby/2.1.0/gems/rubyntlm-0.5.2/lib/net/ntlm/encode_util.rb:42:in `encode_utf16le': undefined method `encoding' for nil:NilClass (NoMethodError)
```
When passing in a `:domain` option