### PR TITLE
Protect against mutating frozen strings

### DIFF
--- a/lib/net/ntlm/encode_util.rb
+++ b/lib/net/ntlm/encode_util.rb
@@ -27,7 +27,7 @@ module NTLM
       # Decode a UTF16 string to a ASCII string
       # @param [String] str The string to convert
       def self.decode_utf16le(str)
-        str.force_encoding(Encoding::UTF_16LE)
+        str = str.dup.force_encoding(Encoding::UTF_16LE)
         str.encode(Encoding::UTF_8, Encoding::UTF_16LE).force_encoding('UTF-8')
       end
 
@@ -39,7 +39,6 @@ module NTLM
       #   the function will convert the string bytes to UTF-16LE and note the encoding as UTF-8 so that byte
       #   concatination works seamlessly.
       def self.encode_utf16le(str)
-        str = str.force_encoding('UTF-8') if [::Encoding::ASCII_8BIT,::Encoding::US_ASCII].include?(str.encoding)
         str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('UTF-8')
       end
     end

--- a/spec/lib/net/ntlm/encode_util_spec.rb
+++ b/spec/lib/net/ntlm/encode_util_spec.rb
@@ -4,13 +4,13 @@ describe Net::NTLM::EncodeUtil do
 
   context '#encode_utf16le' do
     it 'should convert an ASCII string to UTF' do
-      expect(Net::NTLM::EncodeUtil.encode_utf16le('Test')).to eq("T\x00e\x00s\x00t\x00")
+      expect(Net::NTLM::EncodeUtil.encode_utf16le('Test'.encode(::Encoding::ASCII_8BIT).freeze)).to eq("T\x00e\x00s\x00t\x00")
     end
   end
 
   context '#decode_utf16le' do
     it 'should convert a UTF string to ASCII' do
-      expect(Net::NTLM::EncodeUtil.decode_utf16le("T\x00e\x00s\x00t\x00")).to eq('Test')
+      expect(Net::NTLM::EncodeUtil.decode_utf16le("T\x00e\x00s\x00t\x00".freeze)).to eq('Test')
     end
   end
 end


### PR DESCRIPTION
I have seen a few occurence where passing in credential strings that are frozen, usually because they are from environment variables, a `can't modify frozen String` error is raised from rubyntlm.

In this PR, the altered tests demonstrate this:

```
Failures:

  1) Net::NTLM::EncodeUtil#encode_utf16le should convert an ASCII string to UTF
     Failure/Error: str = str.force_encoding('UTF-8') if [::Encoding::ASCII_8BIT,::Encoding::US_ASCII].include?(str.encoding)

     RuntimeError:
       can't modify frozen String
     # ./lib/net/ntlm/encode_util.rb:42:in `force_encoding'
     # ./lib/net/ntlm/encode_util.rb:42:in `encode_utf16le'
     # ./spec/lib/net/ntlm/encode_util_spec.rb:7:in `block (3 levels) in <top (required)>'
```

This PR duplicates the string in decode to ensure the encoding changes occur on a different instance. For `encode_utf16le`, I simply removed:
```
str = str.force_encoding('UTF-8') if [::Encoding::ASCII_8BIT,::Encoding::US_ASCII].include?(str.encoding)
```
which seemed unnecesary given that the next line, which already duplicates the value, begins with the same forced encoding.