### PR TITLE
ignore pkg directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .yardoc
 /doc
 Gemfile.lock
+pkg


### PR DESCRIPTION
Noticed this just after a `rake release` that the generated `pkg` directory was included in indexable items.
