### PR TITLE
Support Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.1.9
   - 2.2.0
   - 2.3.1
+  - 2.4.0
 before_install:
   - gem update bundler
 

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -123,7 +123,7 @@ module Net
       end
 
       def apply_des(plain, keys)
-        dec = OpenSSL::Cipher::Cipher.new("des-cbc")
+        dec = OpenSSL::Cipher.new("des-cbc")
         dec.padding = 0
         keys.map {|k|
           dec.key = k

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -36,7 +36,7 @@ module Net
         t3 = Message::Type3.create type3_opts
         if negotiate_key_exchange?
           t3.enable(:session_key)
-          rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+          rc4 = OpenSSL::Cipher.new("rc4")
           rc4.encrypt
           rc4.key = user_session_key
           sk = rc4.update exported_session_key
@@ -125,7 +125,7 @@ module Net
       def client_cipher
         @client_cipher ||=
           begin
-            rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+            rc4 = OpenSSL::Cipher.new("rc4")
             rc4.encrypt
             rc4.key = client_seal_key
             rc4
@@ -135,7 +135,7 @@ module Net
       def server_cipher
         @server_cipher ||=
           begin
-            rc4 = OpenSSL::Cipher::Cipher.new("rc4")
+            rc4 = OpenSSL::Cipher.new("rc4")
             rc4.decrypt
             rc4.key = server_seal_key
             rc4


### PR DESCRIPTION
Remove deprecated warning

```
.rvm/gems/ruby-2.4.0/gems/rubyntlm-0.6.1/lib/net/ntlm/client/session.rb:39: warning: constant OpenSSL::Cipher::Cipher is deprecated
.rvm/gems/ruby-2.4.0/gems/rubyntlm-0.6.1/lib/net/ntlm/client/session.rb:128: warning: constant OpenSSL::Cipher::Cipher is deprecated
.rvm/gems/ruby-2.4.0/gems/rubyntlm-0.6.1/lib/net/ntlm/client/session.rb:138: warning: constant OpenSSL::Cipher::Cipher is deprecated
```