### PR TITLE
Fix an error showing the key not being set on the DES cypher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 2.2.0
   - 2.3.1
   - 2.4.0
+  - 2.6.6
+  - 2.7.1
+  - 3.0.0
 before_install:
   - gem update bundler
 

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -123,11 +123,11 @@ module Net
       end
 
       def apply_des(plain, keys)
-        dec = OpenSSL::Cipher.new("des-cbc")
+        dec = OpenSSL::Cipher.new("des-cbc").encrypt
         dec.padding = 0
         keys.map {|k|
           dec.key = k
-          dec.encrypt.update(plain) + dec.final
+          dec.update(plain) + dec.final
         }
       end
 


### PR DESCRIPTION
As of ruby 3.0, calling encrypt each iteration of the loop when appending the keys for our des-cbc cypher clears the key on that loop, causing open ssl to raise an error about the key not being set.