### PR TITLE
Add anonymous authentication support

### DIFF
--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -87,6 +87,10 @@ module Net
         message + server_cipher.final
       end
 
+      def is_anonymous?
+        username == '' && password == ''
+      end
+
       private
 
 
@@ -236,10 +240,6 @@ module Net
             challenge_message.target_info
           end
         end
-      end
-
-      def is_anonymous?
-        username == '' && password == ''
       end
     end
   end

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -157,7 +157,8 @@ module Net
       end
 
       def use_oem_strings?
-        challenge_message.has_flag? :OEM
+        # @see https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832
+        !challenge_message.has_flag?(:UNICODE) && challenge_message.has_flag?(:OEM)
       end
 
       def negotiate_key_exchange?

--- a/lib/net/ntlm/message.rb
+++ b/lib/net/ntlm/message.rb
@@ -87,7 +87,7 @@ module NTLM
 
     def serialize
       deflag
-      super + security_buffers.map{|n, f| f.value}.join
+      super + security_buffers.map{|n, f| f.value + ("\x00".b * (f.value.length % 2))}.join
     end
 
     def encode64
@@ -117,6 +117,7 @@ module NTLM
       security_buffers.inject(head_size){|cur, a|
         a[1].offset = cur
         cur += a[1].data_size
+        cur += cur % 2
       }
     end
 

--- a/lib/net/ntlm/message.rb
+++ b/lib/net/ntlm/message.rb
@@ -35,7 +35,6 @@ module NTLM
       :TYPE3 => FLAGS[:UNICODE] | FLAGS[:REQUEST_TARGET] | FLAGS[:NTLM] | FLAGS[:ALWAYS_SIGN] | FLAGS[:NTLM2_KEY]
   }
 
-
   # @private false
   class Message < FieldSet
     class << Message
@@ -87,7 +86,7 @@ module NTLM
 
     def serialize
       deflag
-      super + security_buffers.map{|n, f| f.value + ("\x00".b * (f.value.length % 2))}.join
+      super + security_buffers.map{|n, f| f.value + (has_flag?(:UNICODE) ? "\x00".b * (f.value.length % 2) : '')}.join
     end
 
     def encode64
@@ -117,7 +116,7 @@ module NTLM
       security_buffers.inject(head_size){|cur, a|
         a[1].offset = cur
         cur += a[1].data_size
-        cur += cur % 2
+        has_flag?(:UNICODE) ? cur + cur % 2 : cur
       }
     end
 

--- a/spec/lib/net/ntlm/client/session_spec.rb
+++ b/spec/lib/net/ntlm/client/session_spec.rb
@@ -65,4 +65,23 @@ describe Net::NTLM::Client::Session do
     end
   end
 
+  context 'when authenticating anonymously' do
+    let(:inst) { Net::NTLM::Client::Session.new(Net::NTLM::Client.new('', ''), t2_challenge) }
+
+    describe "#authenticate!" do
+      it "should set the response fields correctly" do
+        t3 = inst.authenticate!
+        expect(t3).to be_a(Net::NTLM::Message::Type3)
+        expect(t3.lm_response).to eq("\x00".b)
+        expect(t3.ntlm_response).to eq('')
+      end
+    end
+
+    describe "#is_anonymous?" do
+      it "should be true" do
+        expect(inst.is_anonymous?).to be_truthy
+      end
+    end
+  end
+
 end

--- a/spec/lib/net/ntlm/message/type3_spec.rb
+++ b/spec/lib/net/ntlm/message/type3_spec.rb
@@ -222,4 +222,25 @@ describe Net::NTLM::Message::Type3 do
 
   end
 
+  describe '.serialize' do
+    subject(:message) { described_class.create(opts) }
+    context 'with the UNICODE flag set' do
+      let(:opts) { {lm_response: "\x00".b, ntlm_response: '', domain: '', workstation: '', user: '', flag: Net::NTLM::DEFAULT_FLAGS[:TYPE3] | Net::NTLM::FLAGS[:UNICODE] } }
+
+      it 'should pad the domain field to a multiple of 2' do
+        message.serialize
+        expect(message[:domain][:offset].value % 2).to eq 0
+      end
+
+      it 'should pad the user field to a multiple of 2' do
+        message.serialize
+        expect(message[:user][:offset].value % 2).to eq 0
+      end
+
+      it 'should pad the workstation field to a multiple of 2' do
+        message.serialize
+        expect(message[:workstation][:offset].value % 2).to eq 0
+      end
+    end
+  end
 end


### PR DESCRIPTION
These changes adjust some things to allow the NTLM session to authenticate anonymously (without a username and password).

For both [NTLMv1](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/464551a8-9fc4-428e-b3d3-bc5bfb2e73a5) an [NTLMv2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/5e550938-91d4-459f-b67d-75d70009e3f3), the docs call out that when the username and password are blank strings, the challenge fields should be special values.

>  If (User is set to "" && Passwd is set to "")
     -- Special case for anonymous authentication
     Set NtChallengeResponseLen to 0
     Set NtChallengeResponseMaxLen to 0
     Set NtChallengeResponseBufferOffset to 0
     Set LmChallengeResponse to Z(1)
 Else

This also adjusts the `Message` class to pad security buffer fields to a two byte boundary when the UNICODE flag is set. Per [MS-NLMP Section 2.2.1.3](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/033d32cc-88f9-4483-9bf2-b273055038ce) the user, domain and workstation fields must have offsets that are multiples of 2. A single null byte is used as padding when necessary. When the UNICODE flag is not set, no padding takes place. The padding is necessary because the code path executed when using anonymous authentication sets the `lm_response` field to a single null byte and shifts all fields after it.

The last change adjusts how the character encoding is determined. Per [MS_NLMP Section 2.2.2.5](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832), the UNICODE flag should take priority regardless of the value of the OEM flag. That is to say that when both are set, the "... choice of character set encoding MUST be Unicode".

Lastly some specs that exercise the updated code paths were added.

This was tested in combination with [RubySMB](rapid7/ruby_smb) and the [anonymous_auth](https://github.com/rapid7/ruby_smb/blob/master/examples/anonymous_auth.rb) example.