### PR TITLE
Fix applying DES-CBC when using OpenSSL 3

### DIFF
--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -123,9 +123,9 @@ module Net
       end
 
       def apply_des(plain, keys)
-        dec = OpenSSL::Cipher.new("des-cbc").encrypt
-        dec.padding = 0
         keys.map {|k|
+          dec = OpenSSL::Cipher.new("des-cbc").encrypt
+          dec.padding = 0
           dec.key = k
           dec.update(plain) + dec.final
         }


### PR DESCRIPTION
After calling `#final` on the cipher object, it will return garbage from that moment forward. The cipher object can therefore not be reused in the iteration over keys. Reinitialize it everytime instead.

This seems to be new behaviour in Ruby/OpenSSL3. See also:
https://ruby.github.io/openssl/OpenSSL/Cipher.html#class-OpenSSL::Cipher-label-Calling+Cipher-23final

This fixes #50.