### PR TITLE
gemspec: Drop unused "executables" directive

### DIFF
--- a/rubyntlm.gemspec
+++ b/rubyntlm.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
 
 
   s.files         = `git ls-files`.split($/)
-  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executables.