### PR TITLE
Fix NTLMv2 hash when username contains non-ASCII characters

### DIFF
--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -161,7 +161,18 @@ module Net
         else
           ntlmhash = ntlm_hash(password, opt)
         end
-        userdomain = user.upcase + target
+
+        if opt[:unicode]
+          # Uppercase operation on username containing non-ASCI characters
+          # after behing unicode encoded with `EncodeUtil.encode_utf16le`
+          # doesn't play well. Upcase should be done before encoding.
+          user_upcase = EncodeUtil.decode_utf16le(user).upcase
+          user_upcase = EncodeUtil.encode_utf16le(user_upcase)
+        else
+          user_upcase = user.upcase
+        end
+        userdomain = user_upcase + target
+
         unless opt[:unicode]
           userdomain = EncodeUtil.encode_utf16le(userdomain)
         end

--- a/lib/net/ntlm/encode_util.rb
+++ b/lib/net/ntlm/encode_util.rb
@@ -39,7 +39,7 @@ module NTLM
       #   the function will convert the string bytes to UTF-16LE and note the encoding as UTF-8 so that byte
       #   concatination works seamlessly.
       def self.encode_utf16le(str)
-        str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('UTF-8')
+        str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('ASCII-8BIT')
       end
     end
   end

--- a/spec/lib/net/ntlm/message/type3_spec.rb
+++ b/spec/lib/net/ntlm/message/type3_spec.rb
@@ -222,4 +222,27 @@ describe Net::NTLM::Message::Type3 do
 
   end
 
+  describe '#serialize' do
+    context 'when the username contains non-ASCI characters' do
+      let(:t3) {
+        t2 = Net::NTLM::Message::Type2.new
+        t2.response(
+          {
+            :user => 'Hélène',
+            :password => '123456',
+            :domain => ''
+          },
+          {
+            :ntlmv2 => true,
+            :workstation => 'testlab.local'
+          }
+        )
+      }
+
+      it 'serializes without error' do
+        expect { t3.serialize }.not_to raise_error
+      end
+    end
+  end
+
 end

--- a/spec/lib/net/ntlm_spec.rb
+++ b/spec/lib/net/ntlm_spec.rb
@@ -63,7 +63,7 @@ describe Net::NTLM do
     let(:user) { 'юзер' }
 
     it 'should return the correct ntlmv2 hash' do
-      expect(Net::NTLM::ntlmv2_hash(user, passwd, domain)).to eq(["ba3d357a20233dfc432b727537272bab"].pack("H*"))
+      expect(Net::NTLM::ntlmv2_hash(user, passwd, domain, { unicode: true })).to eq(["a0f4b914a37faeaee884b6b04a20faf0"].pack("H*"))
     end
   end
 

--- a/spec/lib/net/ntlm_spec.rb
+++ b/spec/lib/net/ntlm_spec.rb
@@ -59,6 +59,14 @@ describe Net::NTLM do
     end
   end
 
+  context 'when the username contains non-ASCI characters' do
+    let(:user) { 'юзер' }
+
+    it 'should return the correct ntlmv2 hash' do
+      expect(Net::NTLM::ntlmv2_hash(user, passwd, domain)).to eq(["ba3d357a20233dfc432b727537272bab"].pack("H*"))
+    end
+  end
+
   it 'should generate an lm_response' do
     expect(Net::NTLM::lm_response(
         {


### PR DESCRIPTION
This fixes https://github.com/WinRb/rubyntlm/issues/55.

See the issue for details. After the fix:
```
❯ ruby examples/authenticate.rb 10.0.0.68 юзер 123456
SMB3 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Netbios Name: MYWIN2016
Netbios Domain: TESTLAB
FQDN of the computer: mywin2016.testlab.local
FQDN of the domain: testlab.local
FQDN of the forest: testlab.local
Dialect: 0x0311
OS Version: 10.0.14393
SMB2 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Netbios Name: MYWIN2016
Netbios Domain: TESTLAB
FQDN of the computer: mywin2016.testlab.local
FQDN of the domain: testlab.local
FQDN of the forest: testlab.local
Dialect: 0x0210
OS Version: 10.0.14393
SMB1 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Native OS: Windows Server 2016 Standard 14393
Native LAN Manager: Windows Server 2016 Standard 6.3
Netbios Name: MYWIN2016
Netbios Domain: TESTLAB
FQDN of the computer: mywin2016.testlab.local
FQDN of the domain: testlab.local
FQDN of the forest: testlab.local
Dialect: NT LM 0.12
OS Version: 10.0.14393
SMB2 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Netbios Name: MYWIN2016
Netbios Domain: TESTLAB
FQDN of the computer: mywin2016.testlab.local
FQDN of the domain: testlab.local
FQDN of the forest: testlab.local
Dialect: 0x0210
OS Version: 10.0.14393
SMB3 : (0x00000000) STATUS_SUCCESS: The operation completed successfully.
Netbios Name: MYWIN2016
Netbios Domain: TESTLAB
FQDN of the computer: mywin2016.testlab.local
FQDN of the domain: testlab.local
FQDN of the forest: testlab.local
Dialect: 0x0311
OS Version: 10.0.14393
```