### PR TITLE
Add dependency to `base64` gem

### DIFF
--- a/rubyntlm.gemspec
+++ b/rubyntlm.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 2.11"
   s.add_development_dependency "simplecov"
+  s.add_dependency "base64"
 end


### PR DESCRIPTION
because `base64` is bundled gem since Ruby 3.4.0dev.

https://github.com/ruby/ruby/pull/9550
https://bugs.ruby-lang.org/issues/20187

Here is the LoadError to use `rubyntlm` using Ruby 3.4.0dev. 
https://github.com/yahonda/httpclient/actions/runs/7695505773/job/20968523567#step:4:13
```ruby
/home/runner/work/httpclient/httpclient/vendor/bundle/ruby/3.4.0+0/gems/rubyntlm-0.6.3/lib/net/ntlm.rb:39: warning: base64 was loaded from the standard library, but is not part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.
/home/runner/.rubies/ruby-head/lib/ruby/3.4.0+0/bundled_gems.rb:74:in `require': cannot load such file -- base64 (LoadError)
```