### PR TITLE
Support performing OpenSSL::Digest::MD4 in openSSL 3 by loading legacy provider

### DIFF
--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -146,6 +146,10 @@ module Net
         unless opt[:unicode]
           pwd = EncodeUtil.encode_utf16le(pwd)
         end
+
+        # OpenSSL 3 Support
+        OpenSSL::Provider.load("legacy") if defined?(OpenSSL::Provider)
+
         OpenSSL::Digest::MD4.digest pwd
       end
 


### PR DESCRIPTION

openSSL3 doesn't support MD4 which means any installation with ntlm on openSSL3 using the challenge will be breaking. Hence the loading of the provider. I wonder if its possible to move away from MD4 altogether?

related: https://github.com/WinRb/rubyntlm/issues/57