### PR TITLE
Ensure compatibility with ruby --enable-frozen-string-literal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2019]
-        ruby: ['3.0', '3.1', '3.2', '3.3', 'head']
+        ruby: ['3.0', '3.1', '3.2', '3.3', '3.4', 'head']
         include:
           - os: ubuntu-latest
             ruby: 'truffleruby'
+          - os: ubuntu-latest
+            ruby: '3.4'
+            ruby-opt: '--enable-frozen-string-literal --debug-frozen-string-literal'
+
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -24,4 +28,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake
+    - run: bundle exec rake RUBYOPT="${{ matrix.ruby-opt }}"

--- a/lib/net/ntlm/channel_binding.rb
+++ b/lib/net/ntlm/channel_binding.rb
@@ -17,7 +17,7 @@ module Net
       #   the outer TLS channel
       def initialize(outer_channel)
         @channel = outer_channel
-        @unique_prefix = 'tls-server-end-point'
+        @unique_prefix = 'tls-server-end-point'.dup
         @initiator_addtype = 0
         @initiator_address_length = 0
         @acceptor_addrtype = 0

--- a/lib/net/ntlm/md4.rb
+++ b/lib/net/ntlm/md4.rb
@@ -35,7 +35,7 @@ module NTLM
         end
 
         io = StringIO.new(string)
-        block = ""
+        block = "".dup
 
         while io.read(64, block)
           x = block.unpack("V16")

--- a/lib/net/ntlm/target_info.rb
+++ b/lib/net/ntlm/target_info.rb
@@ -26,7 +26,7 @@ module Net
       attr_reader :av_pairs
 
       def to_s
-        result = ''
+        result = ''.b
         av_pairs.each do |k,v|
           result << k
           result << [v.length].pack('S')

--- a/spec/lib/net/ntlm/channel_binding_spec.rb
+++ b/spec/lib/net/ntlm/channel_binding_spec.rb
@@ -4,7 +4,7 @@ describe Net::NTLM::ChannelBinding do
   let(:certificates_path) { 'spec/support/certificates' }
   let(:sha_256_path) { File.join(certificates_path, 'sha_256_hash.pem') }
   let(:sha_256_cert) { OpenSSL::X509::Certificate.new(File.read(sha_256_path)) }  
-  let(:cert_hash) { "\x04\x0E\x56\x28\xEC\x4A\x98\x29\x91\x70\x73\x62\x03\x7B\xB2\x3C".force_encoding(Encoding::ASCII_8BIT) }
+  let(:cert_hash) { "\x04\x0E\x56\x28\xEC\x4A\x98\x29\x91\x70\x73\x62\x03\x7B\xB2\x3C".b }
 
   subject { Net::NTLM::ChannelBinding.create(sha_256_cert) }
 


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

Since Ruby 2.4 it is possible to run ruby with `--enable-frozen-string-literal` and it's supposed to be the default behavior in the future.

It just require some very minor change for this gem to be compatible.