### PR TITLE
fix encoding md4 digest

### DIFF
--- a/lib/net/ntlm/md4.rb
+++ b/lib/net/ntlm/md4.rb
@@ -13,6 +13,8 @@ module NTLM
       require 'stringio'
 
       def self.digest(string)
+        string = string.force_encoding('UTF-8')
+
         # functions
         mask = (1 << 32) - 1
         f = proc {|x, y, z| x & y | x.^(mask) & z}


### PR DESCRIPTION
We are using the [Viewpoint](https://github.com/WinRb/Viewpoint) gem, which has this gem as a dependency.

When running
```ruby
ews_client = Viewpoint::EWSClient.new(url, username, password)
ews_client.get_folder(:calendar, act_as: user_mail)
```
If the password contains a non-ascii character (like "é")
We get error
```
Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8 (Encoding::CompatibilityError)
  from rubyntlm (0.6.5) lib/net/ntlm/md4.rb:27:in `+'
  from rubyntlm (0.6.5) lib/net/ntlm/md4.rb:27:in `digest'
  from rubyntlm (0.6.5) lib/net/ntlm.rb:154:in `ntlm_hash'
  from rubyntlm (0.6.5) lib/net/ntlm.rb:167:in `ntlmv2_hash'
  from rubyntlm (0.6.5) lib/net/ntlm/message/type2.rb:73:in `response'
  from httpclient (2.8.3) lib/httpclient/auth.rb:563:in `block in get'
  from mutex_m (0.3.0) lib/mutex_m.rb:82:in `synchronize'
  from mutex_m (0.3.0) lib/mutex_m.rb:82:in `mu_synchronize'
  from httpclient (2.8.3) lib/httpclient/auth.rb:537:in `get'
  from httpclient (2.8.3) lib/httpclient/auth.rb:97:in `block in filter_request'
  from httpclient (2.8.3) lib/httpclient/auth.rb:95:in `each'
  from httpclient (2.8.3) lib/httpclient/auth.rb:95:in `filter_request'
  from httpclient (2.8.3) lib/httpclient.rb:1231:in `block in do_get_block'
  from httpclient (2.8.3) lib/httpclient.rb:1230:in `each'
  from httpclient (2.8.3) lib/httpclient.rb:1230:in `do_get_block'
  from newrelic_rpm (9.19.0) lib/new_relic/agent/instrumentation/httpclient/prepend.rb:11:in `block in do_get_block'
  from newrelic_rpm (9.19.0) lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb:25:in `block in with_tracing'
  from newrelic_rpm (9.19.0) lib/new_relic/agent/tracer.rb:357:in `capture_segment_error'
  from newrelic_rpm (9.19.0) lib/new_relic/agent/instrumentation/httpclient/instrumentation.rb:24:in `with_tracing'
  from newrelic_rpm (9.19.0) lib/new_relic/agent/instrumentation/httpclient/prepend.rb:11:in `do_get_block'
  from httpclient (2.8.3) lib/httpclient.rb:1019:in `block in do_request'
  from httpclient (2.8.3) lib/httpclient.rb:1133:in `protect_keep_alive_disconnected'
  from httpclient (2.8.3) lib/httpclient.rb:1014:in `do_request'
  from httpclient (2.8.3) lib/httpclient.rb:856:in `request'
  from httpclient (2.8.3) lib/httpclient.rb:765:in `post'
  from viewpoint (1.1.1) lib/ews/connection.rb:103:in `post'
  from viewpoint (1.1.1) lib/ews/connection.rb:81:in `dispatch'
  from viewpoint (1.1.1) lib/ews/soap/exchange_web_service.rb:212:in `do_soap_request'
  from viewpoint (1.1.1) lib/ews/soap/exchange_data_services.rb:538:in `get_folder'
  from viewpoint (1.1.1) lib/ews/folder_accessors.rb:62:in `get_folder'
  from app/services/conferencing/exchange/meeting_events_retriever.rb:9:in `block in call'
...
```

Adding this line fixed it, though I must admit I'm not entirely sure why the string is passed as an ascii to the function, so there may be a cleaner fix.