### PR TITLE
mark buffer string as mutable

### DIFF
--- a/lib/net/ntlm/md4.rb
+++ b/lib/net/ntlm/md4.rb
@@ -35,7 +35,7 @@ module NTLM
         end
 
         io = StringIO.new(string)
-        block = ""
+        block = +""
 
         while io.read(64, block)
           x = block.unpack("V16")


### PR DESCRIPTION
This should silence the following deprecation warning:

```
DEPRECATION WARNING: calling `#add` is deprecated. Use `#set` instead.
/home/vendor/ruby/3.4.0/gems/rubyntlm-0.6.5/lib/net/ntlm/md4.rb:40: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```