### PR TITLE
Release 0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.6.6 (2026-09-09)
+
+* Security: fix NTLMv2 authentication bypass in `Type3#password?`, which verified NTLMv2 responses against an empty password instead of the supplied one
+* Fix binary padding in the Ruby MD4 fallback so non-ASCII passwords hash correctly under OpenSSL 3
+
 ## 0.6.5 (2024-06-11)
 
 * Update available NegotiateFlags during authentication

--- a/lib/net/ntlm/version.rb
+++ b/lib/net/ntlm/version.rb
@@ -4,7 +4,7 @@ module Net
     module VERSION
       MAJOR = 0
       MINOR = 6
-      TINY  = 5
+      TINY  = 6
       STRING = [MAJOR, MINOR, TINY].join('.')
     end
   end


### PR DESCRIPTION
Security patch release: fixes the NTLMv2 password verification bypass (see security advisory) and the MD4 fallback padding for non-ASCII passwords under OpenSSL 3.