### PR TITLE
Add trusted-publishing gem push workflow

### DIFF
--- a/.github/workflows/gem_push.yml
+++ b/.github/workflows/gem_push.yml
@@ -1,0 +1,22 @@
+name: Push gem
+on:
+  release:
+    types: [published]
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    environment: release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3"
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@7f9650160c1a4e7989fdc9855807bdbd421d8b6b # v1.4.1


### PR DESCRIPTION
Mirrors savon's `gem_push.yml`: on a published GitHub release, builds the gem and pushes it to RubyGems.org via OIDC trusted publishing (`rubygems/release-gem`).

The `release` environment gates the push behind a manual approval, same as savon.

Before first use:
1. On rubygems.org, add a trusted publisher for the `rubyntlm` gem pointing at this repo / workflow (`gem_push.yml`, environment `release`).
2. In repo Settings > Environments, add required reviewers to the `release` environment (it is created automatically on the first run).

Note: v0.6.6 is already published, so this workflow will only fire for future releases.