### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/rubyntlm.gemspec
+++ b/rubyntlm.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/winrb/rubyntlm'
 
 
-  s.files         = `git ls-files`.split($/)
+  s.files         = `git ls-files lib`.split($/) + ["CHANGELOG.md", "LICENSE", "README.md"]
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 3.0.0'


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 36K	before.tar
 20K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 36K   | 20K   | −16K (⏷ −44.4%)   |


###  whitch files was deleted?

```diff
data
-├── .devcontainer
-│   └── devcontainer.json
-├── .github
-│   ├── workflows
-│   │   └── build.yml
-│   └── dependabot.yml
-├── examples
-│   ├── http.rb
-│   ├── imap.rb
-│   └── smtp.rb
 ├── lib
 │   ├── net
 │   │   ├── ntlm
 │   │   │   ├── client
 │   │   │   │   └── session.rb
 │   │   │   ├── message
 │   │   │   │   ├── type0.rb
 │   │   │   │   ├── type1.rb
 │   │   │   │   ├── type2.rb
 │   │   │   │   └── type3.rb
 │   │   │   ├── blob.rb
 │   │   │   ├── channel_binding.rb
 │   │   │   ├── client.rb
 │   │   │   ├── encode_util.rb
 │   │   │   ├── exceptions.rb
 │   │   │   ├── field_set.rb
 │   │   │   ├── field.rb
 │   │   │   ├── int16_le.rb
 │   │   │   ├── int32_le.rb
 │   │   │   ├── int64_le.rb
 │   │   │   ├── md4.rb
 │   │   │   ├── message.rb
 │   │   │   ├── rc4.rb
 │   │   │   ├── security_buffer.rb
 │   │   │   ├── string.rb
 │   │   │   ├── target_info.rb
 │   │   │   └── version.rb
 │   │   └── ntlm.rb
 │   └── rubyntlm.rb
-├── spec
-│   ├── lib
-│   │   └── net
-│   │       ├── ntlm
-│   │       │   ├── client
-│   │       │   │   └── session_spec.rb
-│   │       │   ├── message
-│   │       │   │   ├── type0_spec.rb
-│   │       │   │   ├── type1_spec.rb
-│   │       │   │   ├── type2_spec.rb
-│   │       │   │   └── type3_spec.rb
-│   │       │   ├── blob_spec.rb
-│   │       │   ├── channel_binding_spec.rb
-│   │       │   ├── client_spec.rb
-│   │       │   ├── encode_util_spec.rb
-│   │       │   ├── field_set_spec.rb
-│   │       │   ├── field_spec.rb
-│   │       │   ├── int16_le_spec.rb
-│   │       │   ├── int32_le_spec.rb
-│   │       │   ├── int64_le_spec.rb
-│   │       │   ├── message_spec.rb
-│   │       │   ├── security_buffer_spec.rb
-│   │       │   ├── string_spec.rb
-│   │       │   ├── target_info_spec.rb
-│   │       │   └── version_spec.rb
-│   │       └── ntlm_spec.rb
-│   ├── support
-│   │   ├── certificates
-│   │   │   └── sha_256_hash.pem
-│   │   └── shared
-│   │       └── examples
-│   │           └── net
-│   │               └── ntlm
-│   │                   ├── field_shared.rb
-│   │                   ├── fieldset_shared.rb
-│   │                   ├── int_shared.rb
-│   │                   └── message_shared.rb
-│   └── spec_helper.rb
-├── .gitignore
-├── .rspec
 ├── CHANGELOG.md
-├── Gemfile
 ├── LICENSE
-├── Rakefile
 ├── README.md
-└── rubyntlm.gemspec
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)