### PR TITLE
Fix lint offenses and enforce lint in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,9 +54,6 @@ jobs:
           advanced-security: false # fail the build on findings instead of uploading SARIF
 
   lint:
-    # Advisory-only on this first pass: RuboCop findings are reported for a
-    # later dedicated cleanup, not fixed here.
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,11 +6,20 @@ AllCops:
   TargetRubyVersion: 3.0
   SuggestExtensions: true
   # Example scripts are illustrative, not library code; skip them.
+  # vendor/ holds CI's vendored bundle. Defining Exclude replaces RuboCop's
+  # defaults (which skip vendor/), so it must be restated here.
   Exclude:
     - 'examples/**/*'
+    - 'vendor/**/*'
 
 Gemspec/RequireMFA:
   Enabled: true
+
+# The gem intentionally supports a range of rubies (>= 3.0.0) while lint
+# targets the oldest supported version, so the floor must not be raised
+# to match TargetRubyVersion.
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent

--- a/lib/net/ntlm.rb
+++ b/lib/net/ntlm.rb
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# frozen_string_literal: true
+
 #
 # = net/ntlm.rb
 #
@@ -61,21 +62,20 @@ require 'net/ntlm/message/type3'
 require 'net/ntlm/encode_util'
 require 'net/ntlm/md4'
 require 'net/ntlm/rc4'
+require 'net/ntlm/response'
 
 require 'net/ntlm/client'
 require 'net/ntlm/channel_binding'
 require 'net/ntlm/target_info'
 
 module Net
+  # Ruby/NTLM library: message creator and parser for NTLM authentication.
   module NTLM
-
     LM_MAGIC = "KGS!@\#$%"
-    TIME_OFFSET = 11644473600
+    TIME_OFFSET = 11_644_473_600
     MAX64 = 0xffffffffffffffff
 
-
     class << self
-
       # Valid format for LAN Manager hex digest portion: 32 hexadecimal characters.
       LAN_MANAGER_HEX_DIGEST_REGEXP = /[0-9a-f]{32}/i
       # Valid format for NT LAN Manager hex digest portion: 32 hexadecimal characters.
@@ -86,7 +86,7 @@ module Net
       # Takes a string and determines whether it is a valid NTLM Hash
       # @param [String] the string to validate
       # @return [Boolean] whether or not the string is a valid NTLM hash
-      def is_ntlm_hash?(data)
+      def ntlm_hash?(data)
         decoded_data = data.dup
         decoded_data = EncodeUtil.decode_utf16le(decoded_data)
         if DATA_REGEXP.match(decoded_data)
@@ -96,10 +96,12 @@ module Net
         end
       end
 
+      alias is_ntlm_hash? ntlm_hash?
+
       # Convert the value to a 64-bit little-endian integer
       # @param [String] val The string to convert
       def pack_int64le(val)
-        [val & 0x00000000ffffffff, val >> 32].pack("V2")
+        [val & 0x00000000ffffffff, val >> 32].pack('V2')
       end
 
       # Builds an array of strings that are 7 characters long
@@ -107,9 +109,7 @@ module Net
       # @api private
       def split7(str)
         s = str.dup
-        until s.empty?
-          (ret ||= []).push s.slice!(0, 7)
-        end
+        (ret ||= []).push s.slice!(0, 7) until s.empty?
         ret
       end
 
@@ -118,18 +118,18 @@ module Net
       # @param [String] str String to generate keys for
       # @api private
       def gen_keys(str)
-        split7(str).map{ |str7|
-          bits = split7(str7.unpack("B*")[0]).inject('')\
-            {|ret, tkn| ret += tkn + (tkn.gsub('1', '').size % 2).to_s }
-          [bits].pack("B*")
+        split7(str).map { |str7|
+          bits = split7(str7.unpack1('B*')).inject('')\
+            { |ret, tkn| ret + tkn + (tkn.gsub('1', '').size % 2).to_s }
+          [bits].pack('B*')
         }
       end
 
       def apply_des(plain, keys)
-        keys.map {|k|
+        keys.map { |k|
           # Spec requires des-cbc, but openssl 3 does not support single des
           # by default, so just do triple DES (EDE) with the same key
-          dec = OpenSSL::Cipher.new("des-ede-cbc").encrypt
+          dec = OpenSSL::Cipher.new('des-ede-cbc').encrypt
           dec.padding = 0
           dec.key = k + k
           dec.update(plain) + dec.final
@@ -148,9 +148,7 @@ module Net
       # @option opt :unicode (false) Unicode encode the password
       def ntlm_hash(password, opt = {})
         pwd = password.dup
-        unless opt[:unicode]
-          pwd = EncodeUtil.encode_utf16le(pwd)
-        end
+        pwd = EncodeUtil.encode_utf16le(pwd) unless opt[:unicode]
         Net::NTLM::Md4.digest pwd
       end
 
@@ -159,124 +157,38 @@ module Net
       # @param [String] password The password
       # @param [String] target The domain or workstation to authenticate to
       # @option [Boolean] opt :unicode (false) Unicode encode the domain.
-      def ntlmv2_hash(user, password, target, opt={})
-        if is_ntlm_hash? password
-          decoded_password = EncodeUtil.decode_utf16le(password)
-          ntlmhash = [decoded_password.upcase[33,65]].pack('H32')
-        else
-          ntlmhash = ntlm_hash(password, opt)
-        end
+      def ntlmv2_hash(user, password, target, opt = {})
+        ntlmhash = ntlmv2_key(password, opt)
+        userdomain = ntlmv2_userdomain(user, target, opt)
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmhash, userdomain)
+      end
 
+      private
+
+      def ntlmv2_key(password, opt)
+        if ntlm_hash? password
+          decoded = EncodeUtil.decode_utf16le(password)
+          [decoded.upcase[33, 65]].pack('H32')
+        else
+          ntlm_hash(password, opt)
+        end
+      end
+
+      def ntlmv2_userdomain(user, target, opt)
+        userdomain = ntlmv2_upcase_user(user, opt) + target
+        opt[:unicode] ? userdomain : EncodeUtil.encode_utf16le(userdomain)
+      end
+
+      def ntlmv2_upcase_user(user, opt)
         if opt[:unicode]
           # Uppercase operation on username containing non-ASCI characters
           # after behing unicode encoded with `EncodeUtil.encode_utf16le`
           # doesn't play well. Upcase should be done before encoding.
-          user_upcase = EncodeUtil.decode_utf16le(user).upcase
-          user_upcase = EncodeUtil.encode_utf16le(user_upcase)
+          EncodeUtil.encode_utf16le(EncodeUtil.decode_utf16le(user).upcase)
         else
-          user_upcase = user.upcase
+          user.upcase
         end
-        userdomain = user_upcase + target
-
-        unless opt[:unicode]
-          userdomain = EncodeUtil.encode_utf16le(userdomain)
-        end
-        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmhash, userdomain)
-      end
-
-      def lm_response(arg)
-        begin
-          hash = arg[:lm_hash]
-          chal = arg[:challenge]
-        rescue
-          raise ArgumentError
-        end
-        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
-        keys = gen_keys hash.ljust(21, "\0")
-        apply_des(chal, keys).join
-      end
-
-      def ntlm_response(arg)
-        hash = arg[:ntlm_hash]
-        chal = arg[:challenge]
-        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
-        keys = gen_keys hash.ljust(21, "\0")
-        apply_des(chal, keys).join
-      end
-
-      def ntlmv2_response(arg, opt = {})
-        begin
-          key = arg[:ntlmv2_hash]
-          chal = arg[:challenge]
-          ti = arg[:target_info]
-        rescue
-          raise ArgumentError
-        end
-        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
-
-        if opt[:client_challenge]
-          cc  = opt[:client_challenge]
-        else
-          cc = rand(MAX64)
-        end
-        cc = NTLM::pack_int64le(cc) if cc.is_a?(Integer)
-
-        if opt[:timestamp]
-          ts = opt[:timestamp]
-        else
-          ts = Time.now.to_i
-        end
-        # epoch -> milsec from Jan 1, 1601
-        ts = 10_000_000 * (ts + TIME_OFFSET)
-
-        blob = Blob.new
-        blob.timestamp = ts
-        blob.challenge = cc
-        blob.target_info = ti
-
-        bb = blob.serialize
-
-        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, chal + bb) + bb
-      end
-
-      def lmv2_response(arg, opt = {})
-        key = arg[:ntlmv2_hash]
-        chal = arg[:challenge]
-
-        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
-
-        if opt[:client_challenge]
-          cc  = opt[:client_challenge]
-        else
-          cc = rand(MAX64)
-        end
-        cc = NTLM::pack_int64le(cc) if cc.is_a?(Integer)
-
-        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, key, chal + cc) + cc
-      end
-
-      def ntlm2_session(arg, opt = {})
-        begin
-          passwd_hash = arg[:ntlm_hash]
-          chal = arg[:challenge]
-        rescue
-          raise ArgumentError
-        end
-        chal = NTLM::pack_int64le(chal) if chal.is_a?(Integer)
-
-        if opt[:client_challenge]
-          cc = opt[:client_challenge]
-        else
-          cc = rand(MAX64)
-        end
-        cc = NTLM::pack_int64le(cc) if cc.is_a?(Integer)
-
-        keys = gen_keys(passwd_hash.ljust(21, "\0"))
-        session_hash = OpenSSL::Digest::MD5.digest(chal + cc).slice(0, 8)
-        response = apply_des(session_hash, keys).join
-        [cc.ljust(24, "\0"), response]
       end
     end
-
   end
 end

--- a/lib/net/ntlm/blob.rb
+++ b/lib/net/ntlm/blob.rb
@@ -1,18 +1,20 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
     BLOB_SIGN = 0x00000101
 
+    # NTLMv2 client challenge blob structure.
     class Blob < FieldSet
-      int32LE    :blob_signature, {:value => BLOB_SIGN}
-      int32LE    :reserved,       {:value => 0}
-      int64LE    :timestamp,      {:value => 0}
-      string     :challenge,      {:value => "", :size => 8}
-      int32LE    :unknown1,       {:value => 0}
-      string     :target_info,    {:value => "", :size => 0}
-      int32LE    :unknown2,       {:value => 0}
+      int32_le :blob_signature, { value: BLOB_SIGN }
+      int32_le :reserved, { value: 0 }
+      int64_le :timestamp, { value: 0 }
+      string :challenge, { value: '', size: 8 }
+      int32_le :unknown1, { value: 0 }
+      string :target_info, { value: '', size: 0 }
+      int32_le :unknown2, { value: 0 }
 
-      def parse(str, offset=0)
+      def parse(str, offset = 0)
         # 28 is the length of all fields before the variable-length
         # target_info field.
         if str.size > 28
@@ -23,6 +25,5 @@ module Net
         super
       end
     end
-
   end
 end

--- a/lib/net/ntlm/channel_binding.rb
+++ b/lib/net/ntlm/channel_binding.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
+    # Channel binding data used for the MsvAvChannelBindings AV_PAIR.
     class ChannelBinding
-
       # Creates a ChannelBinding used for Extended Protection Authentication
       # @see http://blogs.msdn.com/b/openspecification/archive/2013/03/26/ntlm-and-channel-binding-hash-aka-exteneded-protection-for-authentication.aspx
       #
@@ -24,9 +26,8 @@ module Net
         @acceptor_address_length = 0
       end
 
-      attr_reader :channel, :unique_prefix, :initiator_addtype
-      attr_reader :initiator_address_length, :acceptor_addrtype
-      attr_reader :acceptor_address_length
+      attr_reader :channel, :unique_prefix, :initiator_addtype, :initiator_address_length, :acceptor_addrtype,
+                  :acceptor_address_length
 
       # Returns a channel binding hash acceptable for use as a AV_PAIR MsvAvChannelBindings
       #   field value as specified in the NTLM protocol
@@ -38,10 +39,7 @@ module Net
 
       def gss_channel_bindings_struct
         @gss_channel_bindings_struct ||= begin
-          token = [initiator_addtype].pack('I')
-          token << [initiator_address_length].pack('I')
-          token << [acceptor_addrtype].pack('I')
-          token << [acceptor_address_length].pack('I')
+          token = pack_address_header
           token << [application_data.length].pack('I')
           token << application_data
           token
@@ -54,11 +52,17 @@ module Net
 
       def application_data
         @application_data ||= begin
-          data = unique_prefix
+          data = +unique_prefix
           data << ':'
           data << channel_hash.digest
           data
         end
+      end
+
+      private
+
+      def pack_address_header
+        [initiator_addtype, initiator_address_length, acceptor_addrtype, acceptor_address_length].pack('I4')
       end
     end
   end

--- a/lib/net/ntlm/client.rb
+++ b/lib/net/ntlm/client.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
+    # High-level NTLM client: builds type1 and type3 messages for a session.
     class Client
-
       DEFAULT_FLAGS = NTLM::FLAGS[:UNICODE] | NTLM::FLAGS[:OEM] |
-        NTLM::FLAGS[:SIGN]   | NTLM::FLAGS[:SEAL]         | NTLM::FLAGS[:REQUEST_TARGET] |
-        NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
-        NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:KEY_EXCHANGE] | NTLM::FLAGS[:KEY56]
+                      NTLM::FLAGS[:SIGN]   | NTLM::FLAGS[:SEAL]         | NTLM::FLAGS[:REQUEST_TARGET] |
+                      NTLM::FLAGS[:NTLM]   | NTLM::FLAGS[:ALWAYS_SIGN]  | NTLM::FLAGS[:NTLM2_KEY] |
+                      NTLM::FLAGS[:KEY128] | NTLM::FLAGS[:KEY_EXCHANGE] | NTLM::FLAGS[:KEY56]
 
       attr_reader :username, :password, :domain, :workstation, :flags
 
@@ -38,9 +40,7 @@ module Net
       end
 
       # @return [Client::Session]
-      def session
-        @session
-      end
+      attr_reader :session
 
       def session_key
         @session.exported_session_key
@@ -57,9 +57,8 @@ module Net
 
         type1
       end
-
     end
   end
 end
 
-require "net/ntlm/client/session"
+require 'net/ntlm/client/session'

--- a/lib/net/ntlm/client/session.rb
+++ b/lib/net/ntlm/client/session.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
+require 'net/ntlm/client/session_crypto'
+
 module Net
   module NTLM
+    # An authenticated NTLM session: message signing, sealing and key exchange.
     class Client::Session
+      include Client::SessionCrypto
 
       VERSION_MAGIC = "\x01\x00\x00\x00"
-      TIME_OFFSET   = 11644473600
+      TIME_OFFSET   = 11_644_473_600
       MAX64         = 0xffffffffffffffff
       CLIENT_TO_SERVER_SIGNING = "session key to client-to-server signing key magic constant\0"
       SERVER_TO_CLIENT_SIGNING = "session key to server-to-client signing key magic constant\0"
@@ -25,50 +31,22 @@ module Net
       # @return [Net::NTLM::Message::Type3]
       def authenticate!
         calculate_user_session_key!
-        type3_opts = {
-          :lm_response   => is_anonymous? ? "\x00".b : lmv2_resp,
-          :ntlm_response => is_anonymous? ? '' : ntlmv2_resp,
-          :domain        => domain,
-          :user          => username,
-          :workstation   => workstation,
-          :flag          => (challenge_message.flag & client.flags)
-        }
-        t3 = Message::Type3.create type3_opts
-        if negotiate_key_exchange?
-          t3.enable(:session_key)
-          rc4 = Net::NTLM::Rc4.new(user_session_key)
-          sk = rc4.encrypt exported_session_key
-          t3.session_key = sk
-        end
+        t3 = Message::Type3.create(type3_options)
+        exchange_session_key(t3) if negotiate_key_exchange?
         t3
-      end
-
-      def exported_session_key
-        @exported_session_key ||=
-          begin
-            if negotiate_key_exchange?
-              OpenSSL::Random.random_bytes(16)
-            else
-              user_session_key
-            end
-          end
       end
 
       def sign_message(message)
         seq = sequence
-        sig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, client_sign_key, "#{seq}#{message}")[0..7]
-        if negotiate_key_exchange?
-          sig = client_cipher.encrypt sig
-        end
+        sig = OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), client_sign_key, "#{seq}#{message}")[0..7]
+        sig = client_cipher.encrypt sig if negotiate_key_exchange?
         "#{VERSION_MAGIC}#{sig}#{seq}"
       end
 
       def verify_signature(signature, message)
-        seq = signature[-4..-1]
-        sig = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, server_sign_key, "#{seq}#{message}")[0..7]
-        if negotiate_key_exchange?
-          sig = server_cipher.encrypt sig
-        end
+        seq = signature[-4..]
+        sig = OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), server_sign_key, "#{seq}#{message}")[0..7]
+        sig = server_cipher.encrypt sig if negotiate_key_exchange?
         "#{VERSION_MAGIC}#{sig}#{seq}" == signature
       end
 
@@ -80,74 +58,38 @@ module Net
         server_cipher.encrypt(emessage)
       end
 
-      def is_anonymous?
+      def anonymous?
         username == '' && password == ''
       end
 
+      alias is_anonymous? anonymous?
+
       private
 
-
-      def user_session_key
-        @user_session_key ||=  nil
+      def type3_options
+        {
+          lm_response: anonymous? ? "\x00".b : lmv2_resp,
+          ntlm_response: anonymous? ? '' : ntlmv2_resp,
+          domain: domain,
+          user: username,
+          workstation: workstation,
+          flag: (challenge_message.flag & client.flags)
+        }
       end
 
-      def sequence
-        [raw_sequence].pack("V*")
-      end
-
-      def raw_sequence
-        if defined? @raw_sequence
-          @raw_sequence += 1
-        else
-          @raw_sequence = 0
-        end
-      end
-
-      def client_sign_key
-        @client_sign_key ||= OpenSSL::Digest::MD5.digest "#{exported_session_key}#{CLIENT_TO_SERVER_SIGNING}"
-      end
-
-      def server_sign_key
-        @server_sign_key ||= OpenSSL::Digest::MD5.digest "#{exported_session_key}#{SERVER_TO_CLIENT_SIGNING}"
-      end
-
-      def client_seal_key
-        @client_seal_key ||= OpenSSL::Digest::MD5.digest "#{exported_session_key}#{CLIENT_TO_SERVER_SEALING}"
-      end
-
-      def server_seal_key
-        @server_seal_key ||= OpenSSL::Digest::MD5.digest "#{exported_session_key}#{SERVER_TO_CLIENT_SEALING}"
-      end
-
-      def client_cipher
-        @client_cipher ||= Net::NTLM::Rc4.new(client_seal_key)
-      end
-
-      def server_cipher
-        @server_cipher ||= Net::NTLM::Rc4.new(server_seal_key)
-      end
-
-      def client_challenge
-        @client_challenge ||= NTLM.pack_int64le(rand(MAX64))
-      end
-
-      def server_challenge
-        @server_challenge ||= challenge_message[:challenge].serialize
-      end
-
-      # epoch -> milsec from Jan 1, 1601
-      # @see http://support.microsoft.com/kb/188768
-      def timestamp
-        @timestamp ||= 10_000_000 * (Time.now.to_i + TIME_OFFSET)
+      def exchange_session_key(type3)
+        type3.enable(:session_key)
+        rc4 = Net::NTLM::Rc4.new(user_session_key)
+        type3.session_key = rc4.encrypt(exported_session_key)
       end
 
       def use_oem_strings?
         # @see https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/99d90ff4-957f-4c8a-80e4-5bfe5a9a9832
-        !challenge_message.has_flag?(:UNICODE) && challenge_message.has_flag?(:OEM)
+        !challenge_message.flag?(:UNICODE) && challenge_message.flag?(:OEM)
       end
 
       def negotiate_key_exchange?
-        challenge_message.has_flag? :KEY_EXCHANGE
+        challenge_message.flag? :KEY_EXCHANGE
       end
 
       def username
@@ -159,11 +101,11 @@ module Net
       end
 
       def workstation
-        (client.workstation ? oem_or_unicode_str(client.workstation) : "")
+        (client.workstation ? oem_or_unicode_str(client.workstation) : '')
       end
 
       def domain
-        (client.domain ? oem_or_unicode_str(client.domain) : "")
+        (client.domain ? oem_or_unicode_str(client.domain) : '')
       end
 
       def oem_or_unicode_str(str)
@@ -171,55 +113,6 @@ module Net
           NTLM::EncodeUtil.decode_utf16le str
         else
           NTLM::EncodeUtil.encode_utf16le str
-        end
-      end
-
-      def ntlmv2_hash
-        @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain, {:client_challenge => client_challenge, :unicode => !use_oem_strings?})
-      end
-
-      def calculate_user_session_key!
-        if is_anonymous?
-          # see MS-NLMP section 3.4
-          @user_session_key = "\x00".b * 16
-        else
-          @user_session_key = OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, nt_proof_str)
-        end
-      end
-
-      def lmv2_resp
-        OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + client_challenge) + client_challenge
-      end
-
-      def ntlmv2_resp
-        nt_proof_str + blob
-      end
-
-      def nt_proof_str
-        @nt_proof_str ||= OpenSSL::HMAC.digest(OpenSSL::Digest::MD5.new, ntlmv2_hash, server_challenge + blob)
-      end
-
-      def blob
-        @blob ||=
-          begin
-            b = Blob.new
-            b.timestamp = timestamp
-            b.challenge = client_challenge
-            b.target_info = target_info
-            b.serialize
-          end
-      end
-
-      def target_info
-        @target_info ||= begin
-          if channel_binding
-            t = Net::NTLM::TargetInfo.new(challenge_message.target_info)
-            av_id = Net::NTLM::TargetInfo::MSV_AV_CHANNEL_BINDINGS
-            t.av_pairs[av_id] = channel_binding.channel_binding_token
-            t.to_s
-          else
-            challenge_message.target_info
-          end
         end
       end
     end

--- a/lib/net/ntlm/client/session_crypto.rb
+++ b/lib/net/ntlm/client/session_crypto.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module Net
+  module NTLM
+    class Client
+      # Session key derivation and NTLMv2 response building for
+      # {Net::NTLM::Client::Session}. Included into Session; not used directly.
+      module SessionCrypto
+        # @return [String] session key exchanged with (or derived for) the server
+        def exported_session_key
+          @exported_session_key ||=
+            if negotiate_key_exchange?
+              OpenSSL::Random.random_bytes(16)
+            else
+              user_session_key
+            end
+        end
+
+        private
+
+        def user_session_key
+          @user_session_key ||= nil
+        end
+
+        def calculate_user_session_key!
+          @user_session_key = if anonymous?
+                                # see MS-NLMP section 3.4
+                                "\x00".b * 16
+                              else
+                                OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmv2_hash, nt_proof_str)
+                              end
+        end
+
+        def ntlmv2_hash
+          @ntlmv2_hash ||= NTLM.ntlmv2_hash(username, password, domain,
+                                            { client_challenge: client_challenge, unicode: !use_oem_strings? })
+        end
+
+        def lmv2_resp
+          OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmv2_hash,
+                               server_challenge + client_challenge) + client_challenge
+        end
+
+        def ntlmv2_resp
+          nt_proof_str + blob
+        end
+
+        def nt_proof_str
+          @nt_proof_str ||= OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), ntlmv2_hash, server_challenge + blob)
+        end
+
+        def blob
+          @blob ||=
+            begin
+              b = Blob.new
+              b.timestamp = timestamp
+              b.challenge = client_challenge
+              b.target_info = target_info
+              b.serialize
+            end
+        end
+
+        def target_info
+          @target_info ||= if channel_binding
+                             t = Net::NTLM::TargetInfo.new(challenge_message.target_info)
+                             av_id = Net::NTLM::TargetInfo::MSV_AV_CHANNEL_BINDINGS
+                             t.av_pairs[av_id] = channel_binding.channel_binding_token
+                             t.to_s
+                           else
+                             challenge_message.target_info
+                           end
+        end
+
+        def client_sign_key
+          @client_sign_key ||= OpenSSL::Digest.digest('MD5', "#{exported_session_key}#{CLIENT_TO_SERVER_SIGNING}")
+        end
+
+        def server_sign_key
+          @server_sign_key ||= OpenSSL::Digest.digest('MD5', "#{exported_session_key}#{SERVER_TO_CLIENT_SIGNING}")
+        end
+
+        def client_seal_key
+          @client_seal_key ||= OpenSSL::Digest.digest('MD5', "#{exported_session_key}#{CLIENT_TO_SERVER_SEALING}")
+        end
+
+        def server_seal_key
+          @server_seal_key ||= OpenSSL::Digest.digest('MD5', "#{exported_session_key}#{SERVER_TO_CLIENT_SEALING}")
+        end
+
+        def client_cipher
+          @client_cipher ||= Net::NTLM::Rc4.new(client_seal_key)
+        end
+
+        def server_cipher
+          @server_cipher ||= Net::NTLM::Rc4.new(server_seal_key)
+        end
+
+        def client_challenge
+          @client_challenge ||= NTLM.pack_int64le(rand(MAX64))
+        end
+
+        def server_challenge
+          @server_challenge ||= challenge_message[:challenge].serialize
+        end
+
+        # epoch -> milsec from Jan 1, 1601
+        # @see http://support.microsoft.com/kb/188768
+        def timestamp
+          @timestamp ||= 10_000_000 * (Time.now.to_i + TIME_OFFSET)
+        end
+
+        def sequence
+          [raw_sequence].pack('V*')
+        end
+
+        def raw_sequence
+          if defined? @raw_sequence
+            @raw_sequence += 1
+          else
+            @raw_sequence = 0
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ntlm/encode_util.rb
+++ b/lib/net/ntlm/encode_util.rb
@@ -1,48 +1,49 @@
+# frozen_string_literal: true
+
 module Net
-module NTLM
+  module NTLM
+    # UTF-16LE string encoding and decoding helpers.
+    class EncodeUtil
+      if RUBY_VERSION == '1.8.7'
+        require 'kconv'
 
-  class EncodeUtil
-    if RUBY_VERSION == "1.8.7"
-      require "kconv"
+        # Decode a UTF16 string to a ASCII string
+        # @param [String] str The string to convert
+        def self.decode_utf16le(str)
+          Kconv.kconv(swap16(str), Kconv::ASCII, Kconv::UTF16)
+        end
 
-      # Decode a UTF16 string to a ASCII string
-      # @param [String] str The string to convert
-      def self.decode_utf16le(str)
-        Kconv.kconv(swap16(str), Kconv::ASCII, Kconv::UTF16)
-      end
+        # Encodes a ASCII string to a UTF16 string
+        # @param [String] str The string to convert
+        def self.encode_utf16le(str)
+          swap16(Kconv.kconv(str, Kconv::UTF16, Kconv::ASCII))
+        end
 
-      # Encodes a ASCII string to a UTF16 string
-      # @param [String] str The string to convert
-      def self.encode_utf16le(str)
-        swap16(Kconv.kconv(str, Kconv::UTF16, Kconv::ASCII))
-      end
+        # Taggle the strings endianness between big/little and little/big
+        # @param [String] str The string to swap the endianness on
+        def self.swap16(str)
+          str.unpack('v*').pack('n*')
+        end
+      else # Use native 1.9 string encoding functions
 
-      # Taggle the strings endianness between big/little and little/big
-      # @param [String] str The string to swap the endianness on
-      def self.swap16(str)
-        str.unpack("v*").pack("n*")
-      end
-    else # Use native 1.9 string encoding functions
+        # Decode a UTF16 string to a ASCII string
+        # @param [String] str The string to convert
+        def self.decode_utf16le(str)
+          str = str.dup.force_encoding(Encoding::UTF_16LE)
+          str.encode(Encoding::UTF_8, Encoding::UTF_16LE).force_encoding('UTF-8')
+        end
 
-      # Decode a UTF16 string to a ASCII string
-      # @param [String] str The string to convert
-      def self.decode_utf16le(str)
-        str = str.dup.force_encoding(Encoding::UTF_16LE)
-        str.encode(Encoding::UTF_8, Encoding::UTF_16LE).force_encoding('UTF-8')
-      end
-
-      # Encodes a ASCII string to a UTF16 string
-      # @param [String] str The string to convert
-      # @note This implementation may seem stupid but the problem is that UTF16-LE and UTF-8 are incompatiable
-      #   encodings. This library uses string contatination to build the packet bytes. The end result is that
-      #   you can either marshal the encodings elsewhere of simply know that each time you call encode_utf16le
-      #   the function will convert the string bytes to UTF-16LE and note the encoding as UTF-8 so that byte
-      #   concatination works seamlessly.
-      def self.encode_utf16le(str)
-        str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('ASCII-8BIT')
+        # Encodes a ASCII string to a UTF16 string
+        # @param [String] str The string to convert
+        # @note This implementation may seem stupid but the problem is that UTF16-LE and UTF-8 are incompatiable
+        #   encodings. This library uses string contatination to build the packet bytes. The end result is that
+        #   you can either marshal the encodings elsewhere of simply know that each time you call encode_utf16le
+        #   the function will convert the string bytes to UTF-16LE and note the encoding as UTF-8 so that byte
+        #   concatination works seamlessly.
+        def self.encode_utf16le(str)
+          str.dup.force_encoding('UTF-8').encode(Encoding::UTF_16LE, Encoding::UTF_8).force_encoding('ASCII-8BIT')
+        end
       end
     end
   end
-
-end
 end

--- a/lib/net/ntlm/exceptions.rb
+++ b/lib/net/ntlm/exceptions.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
     class NtlmError < StandardError; end
 
+    # Raised when target info AV_PAIR data cannot be parsed.
     class InvalidTargetDataError < NtlmError
       attr_reader :data
 

--- a/lib/net/ntlm/field.rb
+++ b/lib/net/ntlm/field.rb
@@ -1,35 +1,33 @@
+# frozen_string_literal: true
+
 module Net
-module NTLM
+  module NTLM
+    # base classes for primitives
+    # @private
+    class Field
+      attr_accessor :active, :value
 
-  # base classes for primitives
-  # @private
-  class Field
-    attr_accessor :active, :value
+      def initialize(opts)
+        @value  = opts[:value]
+        @active = opts[:active].nil? || opts[:active]
+        @size   = opts[:size].nil? ? 0 : opts[:size]
+      end
 
-    def initialize(opts)
-      @value  = opts[:value]
-      @active = opts[:active].nil? ? true : opts[:active]
-      @size   = opts[:size].nil? ? 0 : opts[:size]
+      def size
+        @active ? @size : 0
+      end
+
+      # Serializer function for field data
+      # Exists in this class to be overridden by child classes
+      def serialize
+        raise NotImplementedError
+      end
+
+      # Parser function for field data
+      # Exists in this class to be overridden by child classes
+      def parse(str, offset = 0)
+        raise NotImplementedError
+      end
     end
-
-    def size
-      @active ? @size : 0
-    end
-
-    # Serializer function for field data
-    # Exists in this class to be overridden by child classes
-    def serialize
-      raise NotImplementedError
-    end
-
-    # Parser function for field data
-    # Exists in this class to be overridden by child classes
-    def parse(str, offset=0)
-      raise NotImplementedError
-    end
-
   end
-
-
-end
 end

--- a/lib/net/ntlm/field_set.rb
+++ b/lib/net/ntlm/field_set.rb
@@ -1,10 +1,10 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
     # base class of data structure
     class FieldSet
       class << FieldSet
-
         # @macro string_security_buffer
         #   @method $1
         #   @method $1=
@@ -17,25 +17,40 @@ module Net
         #   @method $1
         #   @method $1=
         #   @return [Int16LE]
-        def int16LE(name, opts)
+        def int16_le(name, opts)
           add_field(name, Net::NTLM::Int16LE, opts)
         end
+
+        # Legacy camelCase alias for {.int16_le}; kept for backward compatibility.
+        # rubocop:disable Naming/MethodName
+        alias int16LE int16_le
+        # rubocop:enable Naming/MethodName
 
         # @macro int32le_security_buffer
         #   @method $1
         #   @method $1=
         #   @return [Int32LE]
-        def int32LE(name, opts)
+        def int32_le(name, opts)
           add_field(name, Net::NTLM::Int32LE, opts)
         end
+
+        # Legacy camelCase alias for {.int32_le}; kept for backward compatibility.
+        # rubocop:disable Naming/MethodName
+        alias int32LE int32_le
+        # rubocop:enable Naming/MethodName
 
         # @macro int64le_security_buffer
         #   @method $1
         #   @method $1=
         #   @return [Int64]
-        def int64LE(name, opts)
+        def int64_le(name, opts)
           add_field(name, Net::NTLM::Int64LE, opts)
         end
+
+        # Legacy camelCase alias for {.int64_le}; kept for backward compatibility.
+        # rubocop:disable Naming/MethodName
+        alias int64LE int64_le
+        # rubocop:enable Naming/MethodName
 
         # @macro security_buffer
         #   @method $1
@@ -51,17 +66,20 @@ module Net
 
         def names
           return [] if @proto.nil?
-          @proto.map{|n, t, o| n}
+
+          @proto.map { |n, _t, _o| n }
         end
 
         def types
           return [] if @proto.nil?
-          @proto.map{|n, t, o| t}
+
+          @proto.map { |_n, t, _o| t }
         end
 
         def opts
           return [] if @proto.nil?
-          @proto.map{|n, t, o| o}
+
+          @proto.map { |_n, _t, o| o }
         end
 
         private
@@ -72,7 +90,7 @@ module Net
         end
 
         def define_accessor(name)
-          module_eval(<<-End, __FILE__, __LINE__ + 1)
+          module_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{name}
             self['#{name}'].value
           end
@@ -80,35 +98,37 @@ module Net
           def #{name}=(val)
             self['#{name}'].value = val
           end
-          End
+          RUBY
         end
       end
 
       def initialize
-        @alist = self.class.prototypes.map{ |n, t, o| [n, t.new(o)] }
+        @alist = self.class.prototypes.map { |n, t, o| [n, t.new(o)] }
       end
 
-      def parse(str, offset=0)
-        @alist.inject(offset){|cur, a| cur += a[1].parse(str, cur)}
+      def parse(str, offset = 0)
+        @alist.inject(offset) { |cur, a| cur + a[1].parse(str, cur) }
       end
 
       def serialize
-        @alist.map{|n, f| f.serialize }.join
+        @alist.map { |_n, f| f.serialize }.join
       end
 
       def size
-        @alist.inject(0){|sum, a| sum += a[1].size}
+        @alist.inject(0) { |sum, a| sum + a[1].size }
       end
 
       def [](name)
         a = @alist.assoc(name.to_s.intern)
         raise ArgumentError, "no such field: #{name}" unless a
+
         a[1]
       end
 
       def []=(name, val)
         a = @alist.assoc(name.to_s.intern)
         raise ArgumentError, "no such field: #{name}" unless a
+
         a[1] = val
       end
 
@@ -120,10 +140,11 @@ module Net
         self[name].active = false
       end
 
-      def has_disabled_fields?
-        @alist.any? { |name, field| !field.active }
+      def disabled_fields?
+        @alist.any? { |_name, field| !field.active }
       end
-    end
 
+      alias has_disabled_fields? disabled_fields?
+    end
   end
 end

--- a/lib/net/ntlm/int16_le.rb
+++ b/lib/net/ntlm/int16_le.rb
@@ -1,16 +1,17 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
+    # 16-bit little-endian integer field.
     class Int16LE < Field
-
       def initialize(opt)
         super(opt)
         @size = 2
       end
 
-      def parse(str, offset=0)
-        if @active and str.size >= offset + @size
-          @value = str[offset, @size].unpack("v")[0]
+      def parse(str, offset = 0)
+        if @active && str.size >= offset + @size
+          @value = str[offset, @size].unpack1('v')
           @size
         else
           0
@@ -18,9 +19,8 @@ module Net
       end
 
       def serialize
-        [@value].pack("v")
+        [@value].pack('v')
       end
     end
-
   end
 end

--- a/lib/net/ntlm/int32_le.rb
+++ b/lib/net/ntlm/int32_le.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
+    # 32-bit little-endian integer field.
     class Int32LE < Field
       def initialize(opt)
         super(opt)
         @size = 4
       end
 
-      def parse(str, offset=0)
-        if @active and str.size >= offset + @size
-          @value = str.slice(offset, @size).unpack("V")[0]
+      def parse(str, offset = 0)
+        if @active && str.size >= offset + @size
+          @value = str.slice(offset, @size).unpack1('V')
           @size
         else
           0
@@ -17,9 +19,8 @@ module Net
       end
 
       def serialize
-        [@value].pack("V") if @active
+        [@value].pack('V') if @active
       end
     end
-
   end
 end

--- a/lib/net/ntlm/int64_le.rb
+++ b/lib/net/ntlm/int64_le.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
+    # 64-bit little-endian integer field.
     class Int64LE < Field
       def initialize(opt)
         super(opt)
         @size = 8
       end
 
-      def parse(str, offset=0)
-        if @active and str.size >= offset + @size
-          d, u = str.slice(offset, @size).unpack("V2")
+      def parse(str, offset = 0)
+        if @active && str.size >= offset + @size
+          d, u = str.slice(offset, @size).unpack('V2')
           @value = (u * 0x100000000 + d)
           @size
         else
@@ -18,9 +20,8 @@ module Net
       end
 
       def serialize
-        [@value & 0x00000000ffffffff, @value >> 32].pack("V2") if @active
+        [@value & 0x00000000ffffffff, @value >> 32].pack('V2') if @active
       end
     end
-
   end
 end

--- a/lib/net/ntlm/md4.rb
+++ b/lib/net/ntlm/md4.rb
@@ -1,81 +1,119 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Net
-module NTLM
+  # Pure-Ruby MD4 digest, used to compute the NTLM hash.
+  module NTLM
+    # MD4 message digest.
+    class Md4
+      begin
+        OpenSSL::Digest.digest('MD4', '')
+      rescue StandardError
+        # libssl-3.0+ doesn't support legacy MD4 -> use our own implementation
 
-  class Md4
+        require 'stringio'
 
-    begin
-      OpenSSL::Digest::MD4.digest("")
-    rescue
-      # libssl-3.0+ doesn't support legacy MD4 -> use our own implementation
+        MD4_MASK = (1 << 32) - 1
+        MD4_INITIAL_STATE = [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476].freeze
 
-      require 'stringio'
+        def self.digest(string)
+          state = MD4_INITIAL_STATE.dup
+          io = StringIO.new(md4_pad(string))
+          block = +''
 
-      def self.digest(string)
-        # functions
-        mask = (1 << 32) - 1
-        f = proc {|x, y, z| x & y | x.^(mask) & z}
-        g = proc {|x, y, z| x & y | x & z | y & z}
-        h = proc {|x, y, z| x ^ y ^ z}
-        r = proc {|v, s| (v << s).&(mask) | (v.&(mask) >> (32 - s))}
+          while io.read(64, block)
+            words = block.unpack('V16')
+            md4_process_block(state, words)
+          end
 
-        # initial hash
-        a, b, c, d = 0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476
-
-        string = string.b
-        bit_len = string.bytesize << 3
-        string += "\x80".b
-        while (string.size % 64) != 56
-          string += "\0"
-        end
-        string = string.force_encoding('ascii-8bit') + [bit_len & mask, bit_len >> 32].pack("V2")
-
-        if string.size % 64 != 0
-          fail "failed to pad to correct length"
+          state.pack('V4')
         end
 
-        io = StringIO.new(string)
-        block = +""
+        class << self
+          private
 
-        while io.read(64, block)
-          x = block.unpack("V16")
+          def md4_pad(string)
+            string = string.b
+            bit_len = string.bytesize << 3
+            string += "\x80".b
+            string += "\0" while (string.size % 64) != 56
+            string = string.force_encoding('ascii-8bit') + [bit_len & MD4_MASK, bit_len >> 32].pack('V2')
 
-          # Process this block.
-          aa, bb, cc, dd = a, b, c, d
-          [0, 4, 8, 12].each {|i|
-            a = r[a + f[b, c, d] + x[i],  3]; i += 1
-            d = r[d + f[a, b, c] + x[i],  7]; i += 1
-            c = r[c + f[d, a, b] + x[i], 11]; i += 1
-            b = r[b + f[c, d, a] + x[i], 19]
-          }
-          [0, 1, 2, 3].each {|i|
-            a = r[a + g[b, c, d] + x[i] + 0x5a827999,  3]; i += 4
-            d = r[d + g[a, b, c] + x[i] + 0x5a827999,  5]; i += 4
-            c = r[c + g[d, a, b] + x[i] + 0x5a827999,  9]; i += 4
-            b = r[b + g[c, d, a] + x[i] + 0x5a827999, 13]
-          }
-          [0, 2, 1, 3].each {|i|
-            a = r[a + h[b, c, d] + x[i] + 0x6ed9eba1,  3]; i += 8
-            d = r[d + h[a, b, c] + x[i] + 0x6ed9eba1,  9]; i -= 4
-            c = r[c + h[d, a, b] + x[i] + 0x6ed9eba1, 11]; i += 8
-            b = r[b + h[c, d, a] + x[i] + 0x6ed9eba1, 15]
-          }
-          a = (a + aa) & mask
-          b = (b + bb) & mask
-          c = (c + cc) & mask
-          d = (d + dd) & mask
+            raise 'failed to pad to correct length' if string.size % 64 != 0
+
+            string
+          end
+
+          def md4_process_block(state, words)
+            saved = state.dup
+            md4_round1(state, words)
+            md4_round2(state, words)
+            md4_round3(state, words)
+            state.map!.with_index { |word, index| (word + saved[index]) & MD4_MASK }
+          end
+
+          def md4_round1(state, words)
+            mix = method(:md4_f)
+            4.times do |round|
+              base = round * 4
+              md4_step(state, 0, words[base], 3, mix)
+              md4_step(state, 3, words[base + 1], 7, mix)
+              md4_step(state, 2, words[base + 2], 11, mix)
+              md4_step(state, 1, words[base + 3], 19, mix)
+            end
+            state
+          end
+
+          def md4_round2(state, words)
+            mix = ->(first, second, third) { md4_g(first, second, third) + 0x5a827999 }
+            4.times do |round|
+              md4_step(state, 0, words[round], 3, mix)
+              md4_step(state, 3, words[round + 4], 5, mix)
+              md4_step(state, 2, words[round + 8], 9, mix)
+              md4_step(state, 1, words[round + 12], 13, mix)
+            end
+            state
+          end
+
+          def md4_round3(state, words)
+            mix = ->(first, second, third) { md4_h(first, second, third) + 0x6ed9eba1 }
+            [0, 2, 1, 3].each do |round|
+              md4_step(state, 0, words[round], 3, mix)
+              md4_step(state, 3, words[round + 8], 9, mix)
+              md4_step(state, 2, words[round + 4], 11, mix)
+              md4_step(state, 1, words[round + 12], 15, mix)
+            end
+            state
+          end
+
+          def md4_step(state, target, word, shift, mix)
+            others = [state[(target + 1) % 4], state[(target + 2) % 4], state[(target + 3) % 4]]
+            state[target] = md4_rotate(state[target] + mix.call(*others) + word, shift)
+          end
+
+          def md4_f(first, second, third)
+            (first & second) | ((first ^ MD4_MASK) & third)
+          end
+
+          def md4_g(first, second, third)
+            (first & second) | (first & third) | (second & third)
+          end
+
+          def md4_h(first, second, third)
+            first ^ second ^ third
+          end
+
+          def md4_rotate(value, shift)
+            ((value << shift) & MD4_MASK) | ((value & MD4_MASK) >> (32 - shift))
+          end
         end
-
-        [a, b, c, d].pack("V4")
-      end
-
-    else
-      # Openssl/libssl provides MD4, so we can use it.
-      def self.digest(string)
-        OpenSSL::Digest::MD4.digest(string)
+      else
+        # Openssl/libssl provides MD4, so we can use it.
+        def self.digest(string)
+          OpenSSL::Digest::MD4.digest(string)
+        end
       end
     end
   end
-end
 end

--- a/lib/net/ntlm/message.rb
+++ b/lib/net/ntlm/message.rb
@@ -1,137 +1,142 @@
+# frozen_string_literal: true
+
 module Net
-module NTLM
+  module NTLM
+    SSP_SIGN = "NTLMSSP\0"
 
-  SSP_SIGN = "NTLMSSP\0"
-
-  # See [2.2.2.5 NEGOTIATE](https://msdn.microsoft.com/en-us/library/cc236650.aspx)
-  FLAGS = {
-      :UNICODE              => 0x00000001,
-      :OEM                  => 0x00000002,
-      :REQUEST_TARGET       => 0x00000004,
-      :SIGN                 => 0x00000010,
-      :SEAL                 => 0x00000020,
-      :NEG_DATAGRAM         => 0x00000040,
-      :NEG_LM_KEY           => 0x00000080,
-      :NTLM                 => 0x00000200,
-      :NEG_ANONYMOUS        => 0x00000800,
-      :DOMAIN_SUPPLIED      => 0x00001000,
-      :WORKSTATION_SUPPLIED => 0x00002000,
-      :ALWAYS_SIGN          => 0x00008000,
-      :TARGET_TYPE_DOMAIN   => 0x00010000,
-      :TARGET_TYPE_SERVER   => 0x00020000,
-      :NTLM2_KEY            => 0x00080000,
-      :NEG_IDENTIFY         => 0x00100000,
-      :NON_NT_SESSION_KEY   => 0x00400000,
-      :TARGET_INFO          => 0x00800000,
-      :NEG_VERSION          => 0x02000000,
-      :KEY128               => 0x20000000,
-      :KEY_EXCHANGE         => 0x40000000,
-      :KEY56                => 0x80000000,
+    # See [2.2.2.5 NEGOTIATE](https://msdn.microsoft.com/en-us/library/cc236650.aspx)
+    FLAGS = {
+      UNICODE: 0x00000001,
+      OEM: 0x00000002,
+      REQUEST_TARGET: 0x00000004,
+      SIGN: 0x00000010,
+      SEAL: 0x00000020,
+      NEG_DATAGRAM: 0x00000040,
+      NEG_LM_KEY: 0x00000080,
+      NTLM: 0x00000200,
+      NEG_ANONYMOUS: 0x00000800,
+      DOMAIN_SUPPLIED: 0x00001000,
+      WORKSTATION_SUPPLIED: 0x00002000,
+      ALWAYS_SIGN: 0x00008000,
+      TARGET_TYPE_DOMAIN: 0x00010000,
+      TARGET_TYPE_SERVER: 0x00020000,
+      NTLM2_KEY: 0x00080000,
+      NEG_IDENTIFY: 0x00100000,
+      NON_NT_SESSION_KEY: 0x00400000,
+      TARGET_INFO: 0x00800000,
+      NEG_VERSION: 0x02000000,
+      KEY128: 0x20000000,
+      KEY_EXCHANGE: 0x40000000,
+      KEY56: 0x80000000,
       # Undocumented flags:
-      :MBZ9                 => 0x00000008,
-      :NETWARE              => 0x00000100,
-      :NEG_NT_ONLY          => 0x00000400,
-      :MBZ7                 => 0x00000800, # alias for :NEG_ANONYMOUS
-      :LOCAL_CALL           => 0x00004000,
-  }.freeze
+      MBZ9: 0x00000008,
+      NETWARE: 0x00000100,
+      NEG_NT_ONLY: 0x00000400,
+      MBZ7: 0x00000800, # alias for :NEG_ANONYMOUS
+      LOCAL_CALL: 0x00004000
+    }.freeze
 
-  FLAG_KEYS = FLAGS.keys.sort{|a, b| FLAGS[a] <=> FLAGS[b] }
+    FLAG_KEYS = FLAGS.keys.sort { |a, b| FLAGS[a] <=> FLAGS[b] }.freeze
 
-  DEFAULT_FLAGS = {
-      :TYPE1 => FLAGS[:UNICODE] | FLAGS[:OEM] | FLAGS[:REQUEST_TARGET] | FLAGS[:NTLM] | FLAGS[:ALWAYS_SIGN] | FLAGS[:NTLM2_KEY],
-      :TYPE2 => FLAGS[:UNICODE],
-      :TYPE3 => FLAGS[:UNICODE] | FLAGS[:REQUEST_TARGET] | FLAGS[:NTLM] | FLAGS[:ALWAYS_SIGN] | FLAGS[:NTLM2_KEY]
-  }
+    DEFAULT_FLAGS = {
+      TYPE1: FLAGS[:UNICODE] | FLAGS[:OEM] | FLAGS[:REQUEST_TARGET] | FLAGS[:NTLM] | FLAGS[:ALWAYS_SIGN] |
+             FLAGS[:NTLM2_KEY],
+      TYPE2: FLAGS[:UNICODE],
+      TYPE3: FLAGS[:UNICODE] | FLAGS[:REQUEST_TARGET] | FLAGS[:NTLM] | FLAGS[:ALWAYS_SIGN] | FLAGS[:NTLM2_KEY]
+    }.freeze
 
-  # @private false
-  class Message < FieldSet
-    class << Message
-      def parse(str)
-        m = Type0.new
-        m.parse(str)
-        case m.type
-        when 1
-          t = Type1.new.parse(str)
-        when 2
-          t = Type2.new.parse(str)
-        when 3
-          t = Type3.new.parse(str)
-        else
-          raise ArgumentError, "unknown type: #{m.type}"
+    # @private false
+    class Message < FieldSet
+      class << Message
+        def parse(str)
+          m = Type0.new
+          m.parse(str)
+          type_class = { 1 => Type1, 2 => Type2, 3 => Type3 }[m.type]
+          raise ArgumentError, "unknown type: #{m.type}" unless type_class
+
+          type_class.new.parse(str)
         end
-        t
+
+        def decode64(str)
+          parse(Base64.decode64(str))
+        end
+      end
+
+      # @return [self]
+      def parse(str)
+        super
+
+        while disabled_fields? && serialize.size < str.size
+          enable_next_disabled_field
+          super
+        end
+
+        self
+      end
+
+      def flag?(flag)
+        (self[:flag].value & FLAGS[flag]) == FLAGS[flag]
+      end
+
+      alias has_flag? flag?
+
+      def flag=(flag)
+        self[:flag].value |= FLAGS[flag]
+      end
+
+      alias set_flag flag=
+
+      def dump_flags
+        FLAG_KEYS.each { |k| print(k, '=', flag?(k), "\n") }
+      end
+
+      def serialize
+        deflag
+        super + security_buffers.map { |_n, f|
+          f.value + (flag?(:UNICODE) ? "\x00".b * (f.value.length % 2) : '')
+        }.join
+      end
+
+      def encode64
+        Base64.encode64(serialize).gsub(/\n/, '')
       end
 
       def decode64(str)
         parse(Base64.decode64(str))
       end
-    end
 
-    # @return [self]
-    def parse(str)
-      super
+      alias head_size size
 
-      while has_disabled_fields? && serialize.size < str.size
-        # enable the next disabled field
-        self.class.names.find { |name| !self[name].active && enable(name) }
-        super
+      def data_size
+        security_buffers.inject(0) { |sum, a| sum + a[1].data_size }
       end
 
-      self
+      def size
+        head_size + data_size
+      end
+
+      def security_buffers
+        @alist.find_all { |_n, f| f.instance_of?(SecurityBuffer) }
+      end
+
+      def deflag
+        security_buffers.inject(head_size) { |cur, a|
+          a[1].offset = cur
+          cur += a[1].data_size
+          flag?(:UNICODE) ? cur + cur % 2 : cur
+        }
+      end
+
+      def data_edge
+        security_buffers.map { |_n, f| f.active ? f.offset : size }.min
+      end
+
+      private
+
+      # enable the next disabled field
+      def enable_next_disabled_field
+        self.class.names.find { |name| !self[name].active && enable(name) }
+      end
     end
-
-    def has_flag?(flag)
-      (self[:flag].value & FLAGS[flag]) == FLAGS[flag]
-    end
-
-    def set_flag(flag)
-      self[:flag].value  |= FLAGS[flag]
-    end
-
-    def dump_flags
-      FLAG_KEYS.each{ |k| print(k, "=", has_flag?(k), "\n") }
-    end
-
-    def serialize
-      deflag
-      super + security_buffers.map{|n, f| f.value + (has_flag?(:UNICODE) ? "\x00".b * (f.value.length % 2) : '')}.join
-    end
-
-    def encode64
-      Base64.encode64(serialize).gsub(/\n/, '')
-    end
-
-    def decode64(str)
-      parse(Base64.decode64(str))
-    end
-
-    alias head_size size
-
-    def data_size
-      security_buffers.inject(0){|sum, a| sum += a[1].data_size}
-    end
-
-    def size
-      head_size + data_size
-    end
-
-
-    def security_buffers
-      @alist.find_all{|n, f| f.instance_of?(SecurityBuffer)}
-    end
-
-    def deflag
-      security_buffers.inject(head_size){|cur, a|
-        a[1].offset = cur
-        cur += a[1].data_size
-        has_flag?(:UNICODE) ? cur + cur % 2 : cur
-      }
-    end
-
-    def data_edge
-      security_buffers.map{ |n, f| f.active ? f.offset : size}.min
-    end
-
   end
-end
 end

--- a/lib/net/ntlm/message/type0.rb
+++ b/lib/net/ntlm/message/type0.rb
@@ -1,16 +1,13 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
     class Message
-
       # sub class definitions
       class Type0 < Message
-        string        :sign,      {:size => 8, :value => SSP_SIGN}
-        int32LE       :type,      {:value => 0}
+        string :sign, { size: 8, value: SSP_SIGN }
+        int32_le :type, { value: 0 }
       end
-
-
     end
   end
 end
-
-

--- a/lib/net/ntlm/message/type1.rb
+++ b/lib/net/ntlm/message/type1.rb
@@ -1,17 +1,16 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
     class Message
-
       # @private false
       class Type1 < Message
-
-        string          :sign,         {:size => 8, :value => SSP_SIGN}
-        int32LE         :type,         {:value => 1}
-        int32LE         :flag,         {:value => DEFAULT_FLAGS[:TYPE1] }
-        security_buffer :domain,       {:value => ""}
-        security_buffer :workstation,  {:value => Socket.gethostname }
-        string          :os_version,   {:size => 8, :value => "", :active => false }
-
+        string :sign, { size: 8, value: SSP_SIGN }
+        int32_le :type, { value: 1 }
+        int32_le :flag, { value: DEFAULT_FLAGS[:TYPE1] }
+        security_buffer :domain,       { value: '' }
+        security_buffer :workstation,  { value: Socket.gethostname }
+        string          :os_version,   { size: 8, value: '', active: false }
       end
     end
   end

--- a/lib/net/ntlm/message/type2.rb
+++ b/lib/net/ntlm/message/type2.rb
@@ -1,18 +1,18 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
     class Message
-
       # @private false
       class Type2 < Message
-
-        string          :sign,        { :size => 8, :value => SSP_SIGN }
-        int32LE         :type,        { :value => 2 }
-        security_buffer :target_name, { :size => 0, :value => "" }
-        int32LE         :flag,        { :value => DEFAULT_FLAGS[:TYPE2] }
-        int64LE         :challenge,   { :value => 0}
-        int64LE         :context,     { :value => 0, :active => false }
-        security_buffer :target_info, { :value => "", :active => false }
-        string          :os_version,  { :size => 8, :value => "", :active => false }
+        string :sign, { size: 8, value: SSP_SIGN }
+        int32_le :type, { value: 2 }
+        security_buffer :target_name, { size: 0, value: '' }
+        int32_le         :flag,        { value: DEFAULT_FLAGS[:TYPE2] }
+        int64_le         :challenge,   { value: 0 }
+        int64_le         :context,     { value: 0, active: false }
+        security_buffer :target_info, { value: '', active: false }
+        string          :os_version,  { size: 8, value: '', active: false }
 
         # Generates a Type 3 response based on the Type 2 Information
         # @return [Type3]
@@ -24,79 +24,99 @@ module Net
         # @note An empty :domain option authenticates to the local machine.
         # @note The :use_default_target has precedence over the :domain option
         def response(arg, opt = {})
-          usr = arg[:user]
-          pwd = arg[:password]
-          domain = arg[:domain] ? arg[:domain].upcase : ""
-          if usr.nil? or pwd.nil?
-            raise ArgumentError, "user and password have to be supplied"
-          end
-
-          if opt[:workstation]
-            ws = opt[:workstation]
-          else
-            ws = Socket.gethostname
-          end
-
-          if opt[:client_challenge]
-            cc  = opt[:client_challenge]
-          else
-            cc = rand(MAX64)
-          end
-          cc = NTLM::pack_int64le(cc) if cc.is_a?(Integer)
-          opt[:client_challenge] = cc
-
-          if has_flag?(:OEM) and opt[:unicode]
-            usr = NTLM::EncodeUtil.decode_utf16le(usr)
-            pwd = NTLM::EncodeUtil.decode_utf16le(pwd)
-            ws  = NTLM::EncodeUtil.decode_utf16le(ws)
-            domain = NTLM::EncodeUtil.decode_utf16le(domain)
-            opt[:unicode] = false
-          end
-
-          if has_flag?(:UNICODE) and !opt[:unicode]
-            usr = NTLM::EncodeUtil.encode_utf16le(usr)
-            pwd = NTLM::EncodeUtil.encode_utf16le(pwd)
-            ws  = NTLM::EncodeUtil.encode_utf16le(ws)
-            domain = NTLM::EncodeUtil.encode_utf16le(domain)
-            opt[:unicode] = true
-          end
-
-          if opt[:use_default_target]
-            domain = self.target_name
-          end
-
-          ti = self.target_info
-
-          chal = self[:challenge].serialize
-
-          if opt[:ntlmv2]
-            ar = {:ntlmv2_hash => NTLM::ntlmv2_hash(usr, pwd, domain, opt), :challenge => chal, :target_info => ti}
-            lm_res = NTLM::lmv2_response(ar, opt)
-            ntlm_res = NTLM::ntlmv2_response(ar, opt)
-          elsif has_flag?(:NTLM2_KEY)
-            ar = {:ntlm_hash => NTLM::ntlm_hash(pwd, opt), :challenge => chal}
-            lm_res, ntlm_res = NTLM::ntlm2_session(ar, opt)
-          else
-            ar = {:lm_hash => NTLM::lm_hash(pwd), :challenge => chal}
-            lm_res = NTLM::lm_response(ar)
-            ar = {:ntlm_hash => NTLM::ntlm_hash(pwd, opt), :challenge => chal}
-            ntlm_res = NTLM::ntlm_response(ar)
-          end
-
-          Type3.create({
-                           :lm_response => lm_res,
-                           :ntlm_response => ntlm_res,
-                           :domain => domain,
-                           :user => usr,
-                           :workstation => ws,
-                           :flag => self.flag
-                       })
+          creds = response_credentials(arg, opt)
+          normalize_response_encoding(creds, opt)
+          creds[:domain] = target_name if opt[:use_default_target]
+          lm_res, ntlm_res = build_responses(creds, opt)
+          build_type3(creds, lm_res, ntlm_res)
         end
 
-      end
+        private
 
+        def response_credentials(arg, opt)
+          usr = arg[:user]
+          pwd = arg[:password]
+          raise ArgumentError, 'user and password have to be supplied' if usr.nil? || pwd.nil?
+
+          build_credentials(usr, pwd, arg, opt)
+        end
+
+        def build_credentials(usr, pwd, arg, opt)
+          {
+            user: usr,
+            password: pwd,
+            domain: arg[:domain] ? arg[:domain].upcase : '',
+            workstation: opt[:workstation] || Socket.gethostname,
+            client_challenge: normalize_client_challenge(opt)
+          }
+        end
+
+        def normalize_client_challenge(opt)
+          cc = opt[:client_challenge] || rand(MAX64)
+          cc = NTLM.pack_int64le(cc) if cc.is_a?(Integer)
+          opt[:client_challenge] = cc
+        end
+
+        def normalize_response_encoding(creds, opt)
+          decode_response_strings(creds, opt) if flag?(:OEM) && opt[:unicode]
+          encode_response_strings(creds, opt) if flag?(:UNICODE) && !opt[:unicode]
+        end
+
+        def decode_response_strings(creds, opt)
+          creds[:user] = NTLM::EncodeUtil.decode_utf16le(creds[:user])
+          creds[:password] = NTLM::EncodeUtil.decode_utf16le(creds[:password])
+          creds[:workstation] = NTLM::EncodeUtil.decode_utf16le(creds[:workstation])
+          creds[:domain] = NTLM::EncodeUtil.decode_utf16le(creds[:domain])
+          opt[:unicode] = false
+        end
+
+        def encode_response_strings(creds, opt)
+          creds[:user] = NTLM::EncodeUtil.encode_utf16le(creds[:user])
+          creds[:password] = NTLM::EncodeUtil.encode_utf16le(creds[:password])
+          creds[:workstation] = NTLM::EncodeUtil.encode_utf16le(creds[:workstation])
+          creds[:domain] = NTLM::EncodeUtil.encode_utf16le(creds[:domain])
+          opt[:unicode] = true
+        end
+
+        def build_responses(creds, opt)
+          challenge = self[:challenge].serialize
+          if opt[:ntlmv2]
+            ntlmv2_responses(creds, challenge, opt)
+          elsif flag?(:NTLM2_KEY)
+            ntlm2_session_responses(creds, challenge, opt)
+          else
+            v1_responses(creds, challenge, opt)
+          end
+        end
+
+        def ntlmv2_responses(creds, challenge, opt)
+          ar = { ntlmv2_hash: NTLM.ntlmv2_hash(creds[:user], creds[:password], creds[:domain], opt),
+                 challenge: challenge, target_info: target_info }
+          [NTLM.lmv2_response(ar, opt), NTLM.ntlmv2_response(ar, opt)]
+        end
+
+        def ntlm2_session_responses(creds, challenge, opt)
+          ar = { ntlm_hash: NTLM.ntlm_hash(creds[:password], opt), challenge: challenge }
+          NTLM.ntlm2_session(ar, opt)
+        end
+
+        def v1_responses(creds, challenge, opt)
+          lm_res = NTLM.lm_response({ lm_hash: NTLM.lm_hash(creds[:password]), challenge: challenge })
+          ntlm_res = NTLM.ntlm_response({ ntlm_hash: NTLM.ntlm_hash(creds[:password], opt), challenge: challenge })
+          [lm_res, ntlm_res]
+        end
+
+        def build_type3(creds, lm_res, ntlm_res)
+          Type3.create({
+            lm_response: lm_res,
+            ntlm_response: ntlm_res,
+            domain: creds[:domain],
+            user: creds[:user],
+            workstation: creds[:workstation],
+            flag: flag
+          })
+        end
+      end
     end
   end
 end
-
-

--- a/lib/net/ntlm/message/type3.rb
+++ b/lib/net/ntlm/message/type3.rb
@@ -1,20 +1,20 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
     class Message
-
       # @private false
       class Type3 < Message
-
-        string          :sign,          {:size => 8, :value => SSP_SIGN}
-        int32LE         :type,          {:value => 3}
-        security_buffer :lm_response,   {:value => ""}
-        security_buffer :ntlm_response, {:value => ""}
-        security_buffer :domain,        {:value => ""}
-        security_buffer :user,          {:value => ""}
-        security_buffer :workstation,   {:value => ""}
-        security_buffer :session_key,   {:value => "", :active => false }
-        int32LE         :flag,          {:value => 0, :active => false }
-        string          :os_version,    {:size => 8, :active => false }
+        string :sign, { size: 8, value: SSP_SIGN }
+        int32_le :type, { value: 3 }
+        security_buffer :lm_response,   { value: '' }
+        security_buffer :ntlm_response, { value: '' }
+        security_buffer :domain,        { value: '' }
+        security_buffer :user,          { value: '' }
+        security_buffer :workstation,   { value: '' }
+        security_buffer :session_key,   { value: '', active: false }
+        int32_le :flag, { value: 0, active: false }
+        string :os_version, { size: 8, active: false }
 
         class << Type3
           # Builds a Type 3 packet
@@ -26,28 +26,33 @@ module Net
           # @option arg [String] :workstation The name of the calling workstation
           # @option arg [String] :session_key The session key
           # @option arg [Integer] :flag Flags for the packet
-          def create(arg, opt ={})
+          def create(arg, _opt = {})
             t = new
             t.lm_response = arg[:lm_response]
             t.ntlm_response = arg[:ntlm_response]
             t.domain = arg[:domain]
             t.user = arg[:user]
-
-            if arg[:workstation]
-              t.workstation = arg[:workstation]
-            end
-
-            if arg[:session_key]
-              t.enable(:session_key)
-              t.session_key = arg[:session_key]
-            end
-
-            if arg[:flag]
-              t.enable(:session_key)
-              t.enable(:flag)
-              t.flag = arg[:flag]
-            end
+            t.workstation = arg[:workstation] if arg[:workstation]
+            enable_session_key(t, arg)
+            enable_flag(t, arg)
             t
+          end
+
+          private
+
+          def enable_session_key(type3, arg)
+            return unless arg[:session_key]
+
+            type3.enable(:session_key)
+            type3.session_key = arg[:session_key]
+          end
+
+          def enable_flag(type3, arg)
+            return unless arg[:flag]
+
+            type3.enable(:session_key)
+            type3.enable(:flag)
+            type3.flag = arg[:flag]
           end
         end
 
@@ -75,7 +80,7 @@ module Net
 
         # @return [Symbol]
         def ntlm_version
-          if ntlm_response.size == 24 && lm_response[0,8] != "\x00"*8 && lm_response[8,16] == "\x00"*16
+          if ntlm_response.size == 24 && lm_response[0, 8] != "\x00" * 8 && lm_response[8, 16] == "\x00" * 16
             :ntlm2_session
           elsif ntlm_response.size == 24
             :ntlmv1
@@ -87,31 +92,28 @@ module Net
         private
 
         def ntlm2_session_password?(password, server_challenge)
-          hash = ntlm_response
-          _lm, empty_hash = NTLM.ntlm2_session(
-            {
-              :ntlm_hash => NTLM.ntlm_hash(password),
-              :challenge => server_challenge,
-            },
-            {
-              :client_challenge => lm_response[0,8]
-            }
-          )
-          hash == empty_hash
+          ntlm_response == ntlm2_session_empty_hash(password, server_challenge)
+        end
+
+        def ntlm2_session_empty_hash(password, server_challenge)
+          NTLM.ntlm2_session(
+            { ntlm_hash: NTLM.ntlm_hash(password), challenge: server_challenge },
+            { client_challenge: lm_response[0, 8] }
+          ).last
         end
 
         def ntlmv2_password?(password, server_challenge)
           # user and domain are already UTF-16LE from the wire; encode the
           # supplied password to match before deriving the verification key.
-          key = NTLM.ntlmv2_hash(user, EncodeUtil.encode_utf16le(password), domain, :unicode => true)
+          key = NTLM.ntlmv2_hash(user, EncodeUtil.encode_utf16le(password), domain, unicode: true)
           server_challenge = NTLM.pack_int64le(server_challenge) if server_challenge.is_a?(Integer)
 
           # Authenticate the exact blob bytes. Rebuilding the blob truncates
           # sub-second timestamps and rejects otherwise valid responses.
           expected_proof = OpenSSL::HMAC.digest(
-            OpenSSL::Digest::MD5.new, key, server_challenge + ntlm_response[16..-1]
+            OpenSSL::Digest.new('MD5'), key, server_challenge + ntlm_response[16..]
           )
-          expected_proof == ntlm_response[0,16]
+          expected_proof == ntlm_response[0, 16]
         end
       end
     end

--- a/lib/net/ntlm/rc4.rb
+++ b/lib/net/ntlm/rc4.rb
@@ -1,59 +1,66 @@
+# frozen_string_literal: true
+
 require 'openssl'
 
 module Net
-module NTLM
+  # NTLM cryptographic primitives.
+  module NTLM
+    begin
+      OpenSSL::Cipher.new('rc4')
+    rescue StandardError
+      # libssl-3.0+ doesn't support legacy Rc4 -> use our own implementation
 
-  begin
-    OpenSSL::Cipher.new("rc4")
-  rescue
-    # libssl-3.0+ doesn't support legacy Rc4 -> use our own implementation
+      # Pure-Ruby RC4 implementation, used when OpenSSL does not provide RC4.
+      class Rc4
+        def initialize(str)
+          raise ArgumentError, 'RC4: Key supplied is blank' if str.eql?('')
 
-    class Rc4
-      def initialize(str)
-        raise ArgumentError, "RC4: Key supplied is blank"  if str.eql?('')
-        initialize_state(str)
-        @q1, @q2 = 0, 0
-      end
+          initialize_state(str)
+          @q1 = 0
+          @q2 = 0
+        end
 
-      def encrypt(text)
-        text.each_byte.map do |b|
+        def encrypt(text)
+          text.each_byte.map { |byte| keystream_byte ^ byte }.pack('C*')
+        end
+
+        private
+
+        # The initial state which is then modified by the key-scheduling algorithm
+        INITIAL_STATE = (0..255).to_a
+
+        # Advances the cipher state and returns the next keystream byte.
+        def keystream_byte
           @q1 = (@q1 + 1) % 256
           @q2 = (@q2 + @state[@q1]) % 256
           @state[@q1], @state[@q2] = @state[@q2], @state[@q1]
-          b ^ @state[(@state[@q1] + @state[@q2]) % 256]
-        end.pack("C*")
+          @state[(@state[@q1] + @state[@q2]) % 256]
+        end
+
+        # Performs the key-scheduling algorithm to initialize the state.
+        def initialize_state(key)
+          i = j = 0
+          @state = INITIAL_STATE.dup
+          key_length = key.length
+          while i < 256
+            j = (j + @state[i] + key.getbyte(i % key_length)) % 256
+            @state[i], @state[j] = @state[j], @state[i]
+            i += 1
+          end
+        end
       end
+    else
+      # Openssl/libssl provides RC4, so we can use it.
+      class Rc4
+        def initialize(str)
+          @ci = OpenSSL::Cipher.new('rc4')
+          @ci.key = str
+        end
 
-      private
-
-      # The initial state which is then modified by the key-scheduling algorithm
-      INITIAL_STATE = (0..255).to_a
-
-      # Performs the key-scheduling algorithm to initialize the state.
-      def initialize_state(key)
-        i = j = 0
-        @state = INITIAL_STATE.dup
-        key_length = key.length
-        while i < 256
-          j = (j + @state[i] + key.getbyte(i % key_length)) % 256
-          @state[i], @state[j] = @state[j], @state[i]
-          i += 1
+        def encrypt(text)
+          @ci.update(text) + @ci.final
         end
       end
     end
-
-  else
-    # Openssl/libssl provides RC4, so we can use it.
-    class Rc4
-      def initialize(str)
-        @ci = OpenSSL::Cipher.new("rc4")
-        @ci.key = str
-      end
-
-      def encrypt(text)
-        @ci.update(text) + @ci.final
-      end
-    end
   end
-end
 end

--- a/lib/net/ntlm/response.rb
+++ b/lib/net/ntlm/response.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Net
+  # NTLM response builders: LM, NTLM, NTLMv2, LMv2 and NTLM2 session responses.
+  module NTLM
+    class << self
+      # Builds an LM response for the given challenge
+      # @param [Hash] arg :lm_hash, :challenge
+      def lm_response(arg)
+        hash, chal = lm_args(arg)
+        keys = gen_keys hash.ljust(21, "\0")
+        apply_des(pack_challenge(chal), keys).join
+      end
+
+      # Builds an NTLM response for the given challenge
+      # @param [Hash] arg :ntlm_hash, :challenge
+      def ntlm_response(arg)
+        hash = arg[:ntlm_hash]
+        chal = arg[:challenge]
+        chal = NTLM.pack_int64le(chal) if chal.is_a?(Integer)
+        keys = gen_keys hash.ljust(21, "\0")
+        apply_des(chal, keys).join
+      end
+
+      # Builds an NTLMv2 response for the given challenge
+      # @param [Hash] arg :ntlmv2_hash, :challenge, :target_info
+      # @option opt [String] :client_challenge 8-byte client challenge
+      # @option opt [Integer] :timestamp Time of the response
+      def ntlmv2_response(arg, opt = {})
+        key, chal, ti = ntlmv2_args(arg)
+        cc = client_challenge(opt)
+        bb = ntlmv2_blob(ti, opt[:timestamp], cc).serialize
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), key, pack_challenge(chal) + bb) + bb
+      end
+
+      # Builds an LMv2 response for the given challenge
+      # @param [Hash] arg :ntlmv2_hash, :challenge
+      # @option opt [String] :client_challenge 8-byte client challenge
+      def lmv2_response(arg, opt = {})
+        key = arg[:ntlmv2_hash]
+        chal = arg[:challenge]
+
+        chal = NTLM.pack_int64le(chal) if chal.is_a?(Integer)
+
+        cc = opt[:client_challenge] || rand(MAX64)
+        cc = NTLM.pack_int64le(cc) if cc.is_a?(Integer)
+
+        OpenSSL::HMAC.digest(OpenSSL::Digest.new('MD5'), key, chal + cc) + cc
+      end
+
+      # Builds an NTLM2 session response for the given challenge
+      # @param [Hash] arg :ntlm_hash, :challenge
+      # @option opt [String] :client_challenge 8-byte client challenge
+      def ntlm2_session(arg, opt = {})
+        passwd_hash, chal = ntlm2_session_args(arg)
+        cc = client_challenge(opt)
+        keys = gen_keys(passwd_hash.ljust(21, "\0"))
+        session_hash = OpenSSL::Digest::MD5.digest(pack_challenge(chal) + cc).slice(0, 8)
+        response = apply_des(session_hash, keys).join
+        [cc.ljust(24, "\0"), response]
+      end
+
+      private
+
+      # @api private
+      def lm_args(arg)
+        [arg[:lm_hash], arg[:challenge]]
+      rescue StandardError
+        raise ArgumentError
+      end
+
+      # @api private
+      def ntlmv2_args(arg)
+        [arg[:ntlmv2_hash], arg[:challenge], arg[:target_info]]
+      rescue StandardError
+        raise ArgumentError
+      end
+
+      # @api private
+      def ntlm2_session_args(arg)
+        [arg[:ntlm_hash], arg[:challenge]]
+      rescue StandardError
+        raise ArgumentError
+      end
+
+      # @api private
+      def client_challenge(opt)
+        cc = opt[:client_challenge] || rand(MAX64)
+        cc = NTLM.pack_int64le(cc) if cc.is_a?(Integer)
+        cc
+      end
+
+      # @api private
+      def pack_challenge(chal)
+        chal.is_a?(Integer) ? NTLM.pack_int64le(chal) : chal
+      end
+
+      # @api private
+      def ntlmv2_blob(target_info, timestamp, challenge)
+        ts = timestamp || Time.now.to_i
+        # epoch -> milsec from Jan 1, 1601
+        ts = 10_000_000 * (ts + TIME_OFFSET)
+
+        blob = Blob.new
+        blob.timestamp = ts
+        blob.challenge = challenge
+        blob.target_info = target_info
+        blob
+      end
+    end
+  end
+end

--- a/lib/net/ntlm/security_buffer.rb
+++ b/lib/net/ntlm/security_buffer.rb
@@ -1,25 +1,26 @@
+# frozen_string_literal: true
 
 module Net
   module NTLM
-
+    # NTLMSSP security buffer: length/allocated/offset triplet plus payload.
     class SecurityBuffer < FieldSet
-
-      int16LE   :length,        {:value => 0}
-      int16LE   :allocated,     {:value => 0}
-      int32LE   :offset,        {:value => 0}
+      int16_le   :length,        { value: 0 }
+      int16_le   :allocated,     { value: 0 }
+      int32_le   :offset,        { value: 0 }
 
       attr_accessor :active
-      def initialize(opts={})
+
+      def initialize(opts = {})
         super()
         @value  = opts[:value]
-        @active = opts[:active].nil? ? true : opts[:active]
+        @active = opts[:active].nil? || opts[:active]
         @size = 8
       end
 
-      def parse(str, offset=0)
-        if @active and str.size >= offset + @size
+      def parse(str, offset = 0)
+        if @active && str.size >= offset + @size
           super(str, offset)
-          @value = str[self.offset, self.length]
+          @value = str[self.offset, length]
           @size
         else
           0
@@ -30,9 +31,7 @@ module Net
         super if @active
       end
 
-      def value
-        @value
-      end
+      attr_reader :value
 
       def value=(val)
         @value = val
@@ -43,6 +42,5 @@ module Net
         @active ? @value.size : 0
       end
     end
-
   end
 end

--- a/lib/net/ntlm/string.rb
+++ b/lib/net/ntlm/string.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
+    # Fixed-size string field.
     class String < Field
       def initialize(opts)
         super(opts)
         @size = opts[:size]
       end
 
-      def parse(str, offset=0)
-        if @active and str.size >= offset + @size
+      def parse(str, offset = 0)
+        if @active && str.size >= offset + @size
           @value = str[offset, @size]
           @size
         else
@@ -20,16 +22,15 @@ module Net
         if @active
           @value.to_s
         else
-          ""
+          ''
         end
       end
 
       def value=(val)
         @value = val
         @size = @value.nil? ? 0 : @value.size
-        @active = (@size > 0)
+        @active = @size.positive?
       end
     end
-
   end
 end

--- a/lib/net/ntlm/target_info.rb
+++ b/lib/net/ntlm/target_info.rb
@@ -1,22 +1,22 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
-
     # Represents a list of AV_PAIR structures
     # @see https://msdn.microsoft.com/en-us/library/cc236646.aspx
     class TargetInfo
-
       # Allowed AvId values for an AV_PAIR
-      MSV_AV_EOL               = "\x00\x00".freeze
-      MSV_AV_NB_COMPUTER_NAME  = "\x01\x00".freeze
-      MSV_AV_NB_DOMAIN_NAME    = "\x02\x00".freeze
-      MSV_AV_DNS_COMPUTER_NAME = "\x03\x00".freeze
-      MSV_AV_DNS_DOMAIN_NAME   = "\x04\x00".freeze
-      MSV_AV_DNS_TREE_NAME     = "\x05\x00".freeze
-      MSV_AV_FLAGS             = "\x06\x00".freeze
-      MSV_AV_TIMESTAMP         = "\x07\x00".freeze
-      MSV_AV_SINGLE_HOST       = "\x08\x00".freeze
-      MSV_AV_TARGET_NAME       = "\x09\x00".freeze
-      MSV_AV_CHANNEL_BINDINGS  = "\x0A\x00".freeze
+      MSV_AV_EOL               = "\x00\x00"
+      MSV_AV_NB_COMPUTER_NAME  = "\x01\x00"
+      MSV_AV_NB_DOMAIN_NAME    = "\x02\x00"
+      MSV_AV_DNS_COMPUTER_NAME = "\x03\x00"
+      MSV_AV_DNS_DOMAIN_NAME   = "\x04\x00"
+      MSV_AV_DNS_TREE_NAME     = "\x05\x00"
+      MSV_AV_FLAGS             = "\x06\x00"
+      MSV_AV_TIMESTAMP         = "\x07\x00"
+      MSV_AV_SINGLE_HOST       = "\x08\x00"
+      MSV_AV_TARGET_NAME       = "\x09\x00"
+      MSV_AV_CHANNEL_BINDINGS  = "\x0A\x00"
 
       # @param av_pair_sequence [String] AV_PAIR list from challenge message
       def initialize(av_pair_sequence)
@@ -26,8 +26,8 @@ module Net
       attr_reader :av_pairs
 
       def to_s
-        result = ''
-        av_pairs.each do |k,v|
+        result = +''
+        av_pairs.each do |k, v|
           result << k
           result << [v.length].pack('S')
           result << v
@@ -40,49 +40,57 @@ module Net
       private
 
       VALID_PAIR_ID = [
-          MSV_AV_EOL,
-          MSV_AV_NB_COMPUTER_NAME,
-          MSV_AV_NB_DOMAIN_NAME,
-          MSV_AV_DNS_COMPUTER_NAME,
-          MSV_AV_DNS_DOMAIN_NAME,
-          MSV_AV_DNS_TREE_NAME,
-          MSV_AV_FLAGS,
-          MSV_AV_TIMESTAMP,
-          MSV_AV_SINGLE_HOST,
-          MSV_AV_TARGET_NAME,
-          MSV_AV_CHANNEL_BINDINGS
+        MSV_AV_EOL,
+        MSV_AV_NB_COMPUTER_NAME,
+        MSV_AV_NB_DOMAIN_NAME,
+        MSV_AV_DNS_COMPUTER_NAME,
+        MSV_AV_DNS_DOMAIN_NAME,
+        MSV_AV_DNS_TREE_NAME,
+        MSV_AV_FLAGS,
+        MSV_AV_TIMESTAMP,
+        MSV_AV_SINGLE_HOST,
+        MSV_AV_TARGET_NAME,
+        MSV_AV_CHANNEL_BINDINGS
       ].freeze
 
       def read_pairs(av_pair_sequence)
-        offset = 0
         result = {}
         return result if av_pair_sequence.nil?
 
-        until offset >= av_pair_sequence.length
-          id = av_pair_sequence[offset..offset+1]
-
-          unless VALID_PAIR_ID.include?(id)
-            raise Net::NTLM::InvalidTargetDataError.new( 
-              "Invalid AvId #{to_hex(id)} in AV_PAIR structure",
-              av_pair_sequence
-            )
-          end
-
-          length = av_pair_sequence[offset+2..offset+3].unpack('S')[0].to_i
-          if length > 0
-            value = av_pair_sequence[offset+4..offset+4+length-1]
-            result[id] = value
-          end
-
-          offset += 4 + length
-        end
+        read_all_pairs(av_pair_sequence, result)
 
         result
       end
 
+      def read_all_pairs(sequence, result)
+        offset = 0
+        loop do
+          offset = read_pair(sequence, offset, result)
+          break if offset >= sequence.length
+        end
+      end
+
+      def read_pair(sequence, offset, result)
+        id = sequence[offset..offset + 1]
+        validate_pair_id(id, sequence)
+        length = sequence[offset + 2..offset + 3].unpack1('S').to_i
+        result[id] = sequence[offset + 4, length] if length.positive?
+        offset + 4 + length
+      end
+
+      def validate_pair_id(id, sequence)
+        return if VALID_PAIR_ID.include?(id)
+
+        raise Net::NTLM::InvalidTargetDataError.new(
+          "Invalid AvId #{to_hex(id)} in AV_PAIR structure",
+          sequence
+        )
+      end
+
       def to_hex(str)
         return nil if str.nil?
-        str.bytes.map {|b| '0x' + b.to_s(16).rjust(2,'0').upcase}.join('-')
+
+        str.bytes.map { |b| "0x#{b.to_s(16).rjust(2, '0').upcase}" }.join('-')
       end
     end
   end

--- a/lib/net/ntlm/version.rb
+++ b/lib/net/ntlm/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Net
   module NTLM
     # @private

--- a/lib/rubyntlm.rb
+++ b/lib/rubyntlm.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'net/ntlm'

--- a/rubyntlm.gemspec
+++ b/rubyntlm.gemspec
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+require 'English'
 require File.join(File.dirname(__FILE__), 'lib', 'net', 'ntlm', 'version')
 
 Gem::Specification.new do |s|
@@ -7,22 +10,21 @@ Gem::Specification.new do |s|
   s.summary = 'Ruby/NTLM library.'
   s.description = 'Ruby/NTLM provides message creator and parser for the NTLM authentication.'
 
-  s.authors = ['Kohei Kajimoto','Paul Morton']
-  s.email = ['koheik@gmail.com','paul.e.morton@gmail.com']
+  s.authors = ['Kohei Kajimoto', 'Paul Morton']
+  s.email = ['koheik@gmail.com', 'paul.e.morton@gmail.com']
   s.homepage = 'https://github.com/winrb/rubyntlm'
 
-
-  s.files         = `git ls-files lib`.split($/) + ["CHANGELOG.md", "LICENSE", "README.md"]
-  s.require_paths = ["lib"]
+  s.files         = `git ls-files lib`.split($INPUT_RECORD_SEPARATOR) + ['CHANGELOG.md', 'LICENSE', 'README.md']
+  s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 3.0.0'
 
   s.license = 'MIT'
 
-  s.add_dependency "base64"
+  s.add_dependency 'base64'
 
-  s.metadata["rubygems_mfa_required"] = "true"
-  s.metadata["source_code_uri"] = s.homepage
-  s.metadata["changelog_uri"] = "#{s.homepage}/blob/master/CHANGELOG.md"
-  s.metadata["bug_tracker_uri"] = "#{s.homepage}/issues"
+  s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['source_code_uri'] = s.homepage
+  s.metadata['changelog_uri'] = "#{s.homepage}/blob/master/CHANGELOG.md"
+  s.metadata['bug_tracker_uri'] = "#{s.homepage}/issues"
 end

--- a/spec/lib/net/ntlm/blob_spec.rb
+++ b/spec/lib/net/ntlm/blob_spec.rb
@@ -1,13 +1,14 @@
-RSpec.describe Net::NTLM::Blob do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Blob do
   fields = [
-      { :name => :blob_signature, :class => Net::NTLM::Int32LE, :value => 257, :active => true },
-      { :name => :reserved, :class => Net::NTLM::Int32LE, :value => 0, :active => true },
-      { :name => :timestamp, :class => Net::NTLM::Int64LE, :value => 0, :active => true },
-      { :name => :challenge, :class => Net::NTLM::String, :value => '', :active => true },
-      { :name => :unknown1, :class => Net::NTLM::Int32LE, :value => 0, :active => true },
-      { :name => :target_info, :class => Net::NTLM::String, :value => '', :active => true },
-      { :name => :unknown2, :class => Net::NTLM::Int32LE, :value => 0, :active => true },
+    { name: :blob_signature, class: Net::NTLM::Int32LE, value: 257, active: true },
+    { name: :reserved, class: Net::NTLM::Int32LE, value: 0, active: true },
+    { name: :timestamp, class: Net::NTLM::Int64LE, value: 0, active: true },
+    { name: :challenge, class: Net::NTLM::String, value: '', active: true },
+    { name: :unknown1, class: Net::NTLM::Int32LE, value: 0, active: true },
+    { name: :target_info, class: Net::NTLM::String, value: '', active: true },
+    { name: :unknown2, class: Net::NTLM::Int32LE, value: 0, active: true }
   ]
 
   it_behaves_like 'a fieldset', fields

--- a/spec/lib/net/ntlm/channel_binding_spec.rb
+++ b/spec/lib/net/ntlm/channel_binding_spec.rb
@@ -1,15 +1,18 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::ChannelBinding do
+  subject(:channel_binding) { described_class.create(sha_256_cert) }
+
   let(:certificates_path) { 'spec/support/certificates' }
   let(:sha_256_path) { File.join(certificates_path, 'sha_256_hash.pem') }
-  let(:sha_256_cert) { OpenSSL::X509::Certificate.new(File.read(sha_256_path)) }  
-  let(:cert_hash) { "\x04\x0E\x56\x28\xEC\x4A\x98\x29\x91\x70\x73\x62\x03\x7B\xB2\x3C".force_encoding(Encoding::ASCII_8BIT) }
-
-  subject { Net::NTLM::ChannelBinding.create(sha_256_cert) }
+  let(:sha_256_cert) { OpenSSL::X509::Certificate.new(File.read(sha_256_path)) }
+  let(:cert_hash) do
+    "\x04\x0E\x56\x28\xEC\x4A\x98\x29\x91\x70\x73\x62\x03\x7B\xB2\x3C".dup.force_encoding(Encoding::ASCII_8BIT)
+  end
 
   describe '#channel_binding_token' do
-
     it 'returns the correct hash' do
-      expect(subject.channel_binding_token).to eq cert_hash
+      expect(channel_binding.channel_binding_token).to eq cert_hash
     end
   end
 end

--- a/spec/lib/net/ntlm/client/session_spec.rb
+++ b/spec/lib/net/ntlm/client/session_spec.rb
@@ -1,85 +1,130 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::Client::Session do
-  let(:t2_challenge) { Net::NTLM::Message.decode64 "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA==" }
-  let(:inst) { Net::NTLM::Client::Session.new(nil, t2_challenge) }
-  let(:user_session_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
-  let(:client_sign_key) {["f7f97a82ec390f9c903dac4f6aceb132"].pack("H*")}
-  let(:client_seal_key) {["6f0d99535033951cbe499cd1914fe9ee"].pack("H*")}
-  let(:server_sign_key) {["f7f97a82ec390f9c903dac4f6aceb132"].pack("H*")}
-  let(:server_seal_key) {["6f0d99535033951cbe499cd1914fe9ee"].pack("H*")}
-
-  describe "#sign_message" do
-
-    it "signs a message and when KEY_EXCHANGE is true" do
-      expect(inst).to receive(:client_sign_key).and_return(client_sign_key)
-      expect(inst).to receive(:client_seal_key).and_return(client_seal_key)
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
-      sm = inst.sign_message("Test Message")
-      str = "01000000b35ccd60c110c52f00000000"
-      expect(sm.unpack("H*")[0]).to eq(str)
-    end
-
+  let(:t2_challenge) { Net::NTLM::Message.decode64 'TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA==' }
+  let(:inst) { described_class.new(nil, t2_challenge) }
+  let(:keys) do
+    {
+      user_session: ['3c4918ff0b33e2603e5d7ceaf34bb7d5'].pack('H*'),
+      client_sign: ['f7f97a82ec390f9c903dac4f6aceb132'].pack('H*'),
+      client_seal: ['6f0d99535033951cbe499cd1914fe9ee'].pack('H*'),
+      server_sign: ['f7f97a82ec390f9c903dac4f6aceb132'].pack('H*'),
+      server_seal: ['6f0d99535033951cbe499cd1914fe9ee'].pack('H*')
+    }
   end
 
-  describe "#verify_signature" do
+  def expect_received(*messages)
+    aggregate_failures do
+      messages.each { |message| expect(inst).to have_received(message) }
+    end
+  end
 
-    it "verifies a message signature" do
-      expect(inst).to receive(:server_sign_key).and_return(server_sign_key)
-      expect(inst).to receive(:server_seal_key).and_return(server_seal_key)
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
-      sig = "01000000b35ccd60c110c52f00000000"
-      sm = inst.verify_signature([sig].pack("H*"), "Test Message")
+  describe '#sign_message' do
+    before do
+      allow(inst).to receive_messages(
+        client_sign_key: keys[:client_sign],
+        client_seal_key: keys[:client_seal],
+        negotiate_key_exchange?: true
+      )
+    end
+
+    it 'signs a message and when KEY_EXCHANGE is true' do
+      sm = inst.sign_message('Test Message')
+      expect(sm.unpack1('H*')).to eq('01000000b35ccd60c110c52f00000000')
+      expect_received(:client_sign_key, :client_seal_key, :negotiate_key_exchange?)
+    end
+  end
+
+  describe '#verify_signature' do
+    before do
+      allow(inst).to receive_messages(
+        server_sign_key: keys[:server_sign],
+        server_seal_key: keys[:server_seal],
+        negotiate_key_exchange?: true
+      )
+    end
+
+    it 'verifies a message signature' do
+      sig = '01000000b35ccd60c110c52f00000000'
+      sm = inst.verify_signature([sig].pack('H*'), 'Test Message')
       expect(sm).to be true
-    end
-
-  end
-
-  describe "#seal_message" do
-    it "should seal the message" do
-      expect(inst).to receive(:client_seal_key).and_return(client_seal_key)
-      emsg = inst.seal_message("rubyntlm")
-      expect(emsg.unpack("H*")[0]).to eq("d7389b9604f6274f")
+      expect_received(:server_sign_key, :server_seal_key, :negotiate_key_exchange?)
     end
   end
 
-  describe "#unseal_message" do
-    it "should unseal the message" do
-      expect(inst).to receive(:server_seal_key).and_return(server_seal_key)
-      msg = inst.unseal_message(["d7389b9604f6274f"].pack("H*"))
-      expect(msg).to eq("rubyntlm")
+  describe '#seal_message' do
+    before do
+      allow(inst).to receive(:client_seal_key).and_return(keys[:client_seal])
+    end
+
+    it 'seals the message' do
+      emsg = inst.seal_message('rubyntlm')
+      aggregate_failures do
+        expect(emsg.unpack1('H*')).to eq('d7389b9604f6274f')
+        expect(inst).to have_received(:client_seal_key)
+      end
     end
   end
 
-  describe "#exported_session_key" do
-    it "returns a random 16-byte key when negotiate_key_exchange? is true" do
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(true)
-      expect(inst).not_to receive(:user_session_key)
+  describe '#unseal_message' do
+    before do
+      allow(inst).to receive(:server_seal_key).and_return(keys[:server_seal])
+    end
+
+    it 'unseals the message' do
+      msg = inst.unseal_message(['d7389b9604f6274f'].pack('H*'))
+      aggregate_failures do
+        expect(msg).to eq('rubyntlm')
+        expect(inst).to have_received(:server_seal_key)
+      end
+    end
+  end
+
+  describe '#exported_session_key' do
+    let(:key_exchange) { true }
+
+    before do
+      allow(inst).to receive_messages(
+        negotiate_key_exchange?: key_exchange,
+        user_session_key: keys[:user_session]
+      )
+    end
+
+    it 'returns a random 16-byte key when negotiate_key_exchange? is true' do
       inst.exported_session_key
+      expect_received(:negotiate_key_exchange?)
+      expect(inst).not_to have_received(:user_session_key)
     end
 
-    it "returns the user_session_key when negotiate_key_exchange? is false" do
-      expect(inst).to receive(:negotiate_key_exchange?).and_return(false)
-      expect(inst).to receive(:user_session_key).and_return(user_session_key)
-      inst.exported_session_key
+    context 'when key exchange is not negotiated' do
+      let(:key_exchange) { false }
+
+      it 'returns the user_session_key' do
+        expect(inst.exported_session_key).to eq(keys[:user_session])
+        expect_received(:negotiate_key_exchange?, :user_session_key)
+      end
     end
   end
 
   context 'when authenticating anonymously' do
-    let(:inst) { Net::NTLM::Client::Session.new(Net::NTLM::Client.new('', ''), t2_challenge) }
+    let(:inst) { described_class.new(Net::NTLM::Client.new('', ''), t2_challenge) }
 
-    describe "#authenticate!" do
-      it "should set the response fields correctly" do
-        t3 = inst.authenticate!
-        expect(t3).to be_a(Net::NTLM::Message::Type3)
-        expect(t3.lm_response).to eq("\x00".b)
-        expect(t3.ntlm_response).to eq('')
+    describe '#authenticate!' do
+      let(:t3) { inst.authenticate! }
+
+      it 'sets the response fields correctly' do
+        aggregate_failures do
+          expect(t3).to be_a(Net::NTLM::Message::Type3)
+          expect(t3.lm_response).to eq("\x00".b)
+          expect(t3.ntlm_response).to eq('')
+        end
       end
     end
 
-    describe "#is_anonymous?" do
-      it "should be true" do
-        expect(inst.is_anonymous?).to be_truthy
+    describe '#is_anonymous?' do
+      it 'is true' do
+        expect(inst).to be_is_anonymous
       end
     end
   end
-
 end

--- a/spec/lib/net/ntlm/client_spec.rb
+++ b/spec/lib/net/ntlm/client_spec.rb
@@ -1,62 +1,77 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::Client do
-  let(:inst) { Net::NTLM::Client.new("test", "test01", :workstation => "testhost") }
-  let(:user_session_key) {["3c4918ff0b33e2603e5d7ceaf34bb7d5"].pack("H*")}
+  let(:inst) { described_class.new('test', 'test01', workstation: 'testhost') }
 
-  describe "#init_context" do
+  describe '#init_context' do
+    let(:t2_challenge) do
+      'TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUg' \
+        'ACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAI' \
+        'ADd7mrNaB9ABAAAAAA=='
+    end
+    let(:session) { instance_spy(Net::NTLM::Client::Session) }
 
-    it "returns a default Type1 message" do
-      t1 = inst.init_context
-      expect(t1).to be_instance_of Net::NTLM::Message::Type1
-      expect(t1.domain).to eq("")
-      expect(t1.workstation).to eq("testhost")
-      expect(t1).to have_flag(:UNICODE)
-      expect(t1).to have_flag(:OEM)
-      expect(t1).to have_flag(:SIGN)
-      expect(t1).to have_flag(:SEAL)
-      expect(t1).to have_flag(:REQUEST_TARGET)
-      expect(t1).to have_flag(:NTLM)
-      expect(t1).to have_flag(:ALWAYS_SIGN)
-      expect(t1).to have_flag(:NTLM2_KEY)
-      expect(t1).to have_flag(:KEY128)
-      expect(t1).to have_flag(:KEY_EXCHANGE)
-      expect(t1).to have_flag(:KEY56)
+    before do
+      allow(Net::NTLM::Client::Session).to receive(:new).and_return(session)
     end
 
-    it "clears session variable on new init_context" do
-      inst.instance_variable_set :@session, "BADSESSION"
-      expect(inst.session).to eq("BADSESSION")
+    it 'returns a Type1 message' do
+      expect(inst.init_context).to be_instance_of Net::NTLM::Message::Type1
+    end
+
+    it 'sets the default domain and workstation' do
+      aggregate_failures do
+        t1 = inst.init_context
+        expect(t1.domain).to eq('')
+        expect(t1.workstation).to eq('testhost')
+      end
+    end
+
+    it 'enables the default flags' do
+      t1 = inst.init_context
+      %i[UNICODE OEM SIGN SEAL REQUEST_TARGET NTLM ALWAYS_SIGN NTLM2_KEY KEY128 KEY_EXCHANGE KEY56].each do |flag|
+        expect(t1).to have_flag(flag)
+      end
+    end
+
+    it 'clears session variable on new init_context' do
+      inst.instance_variable_set :@session, 'BADSESSION'
       inst.init_context
       expect(inst.session).to be_nil
     end
 
-    it "returns a Type1 message with custom flags" do
-      flags = Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM]
-      inst = Net::NTLM::Client.new("test", "test01", :workstation => "testhost", :flags => flags)
-      t1 = inst.init_context
-      expect(t1).to be_instance_of Net::NTLM::Message::Type1
-      expect(t1.domain).to eq("")
-      expect(t1.workstation).to eq("testhost")
-      expect(t1).to have_flag(:UNICODE)
-      expect(t1).not_to have_flag(:OEM)
-      expect(t1).not_to have_flag(:SIGN)
-      expect(t1).not_to have_flag(:SEAL)
-      expect(t1).to have_flag(:REQUEST_TARGET)
-      expect(t1).to have_flag(:NTLM)
-      expect(t1).not_to have_flag(:ALWAYS_SIGN)
-      expect(t1).not_to have_flag(:NTLM2_KEY)
-      expect(t1).not_to have_flag(:KEY128)
-      expect(t1).not_to have_flag(:KEY_EXCHANGE)
-      expect(t1).not_to have_flag(:KEY56)
-    end
-
-    it "calls authenticate! when we receive a Challenge Message" do
-      t2_challenge = "TlRMTVNTUAACAAAADAAMADgAAAA1goriAAyk1DmJUnUAAAAAAAAAAFAAUABEAAAABgLwIwAAAA9TAEUAUgBWAEUAUgACAAwAUwBFAFIAVgBFAFIAAQAMAFMARQBSAFYARQBSAAQADABzAGUAcgB2AGUAcgADAAwAcwBlAHIAdgBlAHIABwAIADd7mrNaB9ABAAAAAA=="
-      session = double("session")
-      expect(session).to receive(:authenticate!)
-      expect(Net::NTLM::Client::Session).to receive(:new).with(inst, instance_of(Net::NTLM::Message::Type2), nil).and_return(session)
+    it 'builds a session from the challenge message' do
       inst.init_context t2_challenge
+      expect(Net::NTLM::Client::Session).to have_received(:new)
+        .with(inst, instance_of(Net::NTLM::Message::Type2), nil)
     end
 
-  end
+    it 'calls authenticate! on the session' do
+      inst.init_context t2_challenge
+      expect(session).to have_received(:authenticate!)
+    end
 
+    context 'with custom flags' do
+      let(:flags) do
+        Net::NTLM::FLAGS[:UNICODE] | Net::NTLM::FLAGS[:REQUEST_TARGET] | Net::NTLM::FLAGS[:NTLM]
+      end
+      let(:inst) { described_class.new('test', 'test01', workstation: 'testhost', flags: flags) }
+      let(:t1) { inst.init_context }
+
+      it 'returns a Type1 message' do
+        expect(t1).to be_instance_of Net::NTLM::Message::Type1
+      end
+
+      it 'sets the domain and workstation' do
+        aggregate_failures do
+          expect(t1.domain).to eq('')
+          expect(t1.workstation).to eq('testhost')
+        end
+      end
+
+      it 'enables only the requested flags' do
+        expect(t1.flag).to eq(flags)
+      end
+    end
+  end
 end

--- a/spec/lib/net/ntlm/encode_util_spec.rb
+++ b/spec/lib/net/ntlm/encode_util_spec.rb
@@ -1,14 +1,15 @@
-RSpec.describe Net::NTLM::EncodeUtil do
+# frozen_string_literal: true
 
-  context '#encode_utf16le' do
-    it 'should convert an ASCII string to UTF' do
-      expect(Net::NTLM::EncodeUtil.encode_utf16le('Test'.encode(::Encoding::ASCII_8BIT).freeze)).to eq("T\x00e\x00s\x00t\x00")
+RSpec.describe Net::NTLM::EncodeUtil do
+  describe '#encode_utf16le' do
+    it 'converts an ASCII string to UTF' do
+      expect(described_class.encode_utf16le('Test'.encode(::Encoding::ASCII_8BIT))).to eq("T\x00e\x00s\x00t\x00")
     end
   end
 
-  context '#decode_utf16le' do
-    it 'should convert a UTF string to ASCII' do
-      expect(Net::NTLM::EncodeUtil.decode_utf16le("T\x00e\x00s\x00t\x00".freeze)).to eq('Test')
+  describe '#decode_utf16le' do
+    it 'converts a UTF string to ASCII' do
+      expect(described_class.decode_utf16le("T\x00e\x00s\x00t\x00")).to eq('Test')
     end
   end
 end

--- a/spec/lib/net/ntlm/field_set_spec.rb
+++ b/spec/lib/net/ntlm/field_set_spec.rb
@@ -1,30 +1,31 @@
-RSpec.describe Net::NTLM::FieldSet do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::FieldSet do
   fields = []
+
+  subject(:fieldset_class) do
+    Class.new(described_class)
+  end
 
   it_behaves_like 'a fieldset', fields
 
-  subject(:fieldset_class) do
-    Class.new(Net::NTLM::FieldSet)
-  end
-
   context 'an instance' do
     subject(:fieldset_object) do
-      fieldset_class.string(:test_string, { :value => 'Test', :active => true, :size => 4})
-      fieldset_class.string(:test_string2, { :value => 'Foo', :active => true, :size => 3})
+      fieldset_class.string(:test_string, { value: 'Test', active: true, size: 4 })
+      fieldset_class.string(:test_string2, { value: 'Foo', active: true, size: 3 })
       fieldset_class.new
     end
 
-    it 'should serialize all the fields' do
+    it 'serializes all the fields' do
       expect(fieldset_object.serialize).to eq('TestFoo')
     end
 
-    it 'should parse a string across the fields' do
+    it 'parses a string across the fields' do
       fieldset_object.parse('FooBarBaz')
       expect(fieldset_object.serialize).to eq('FooBarB')
     end
 
-    it 'should return an aggregate size of all the fields' do
+    it 'returns an aggregate size of all the fields' do
       expect(fieldset_object.size).to eq(7)
     end
   end

--- a/spec/lib/net/ntlm/field_spec.rb
+++ b/spec/lib/net/ntlm/field_spec.rb
@@ -1,32 +1,31 @@
-RSpec.describe Net::NTLM::Field do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Field do
   it_behaves_like 'a field', 'Foo', false
 
   context 'with no size specified' do
-    let (:field_without_size) { Net::NTLM::Field.new({ :value => 'Foo', :active => true }) }
-    it 'should set size to 0 if not active' do
+    let(:field_without_size) { described_class.new({ value: 'Foo', active: true }) }
+
+    it 'sets size to 0 if not active' do
       expect(field_without_size.size).to eq(0)
     end
 
-    it 'should return 0 if active but no size specified' do
+    it 'returns 0 if active but no size specified' do
       field_without_size.active = true
       expect(field_without_size.size).to eq(0)
     end
   end
 
   context 'with a size specified' do
-    let (:field_with_size) { Net::NTLM::Field.new({ :value => 'Foo', :active => true, :size => 100 }) }
+    let(:field_with_size) { described_class.new({ value: 'Foo', active: true, size: 100 }) }
 
-    it 'should return the size provided in the initialize options if active' do
+    it 'returns the size provided in the initialize options if active' do
       expect(field_with_size.size).to eq(100)
     end
 
-    it 'should still return 0 if not active' do
+    it 'stills return 0 if not active' do
       field_with_size.active = false
       expect(field_with_size.size).to eq(0)
     end
   end
-
-
-
 end

--- a/spec/lib/net/ntlm/int16_le_spec.rb
+++ b/spec/lib/net/ntlm/int16_le_spec.rb
@@ -1,16 +1,17 @@
-RSpec.describe Net::NTLM::Int16LE do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Int16LE do
   int_values = {
-    :default     => 15,
-    :default_hex => "\x0F\x00",
-    :alt         => 14,
-    :alt_hex     => "\x0E\x00",
-    :small       => "\x0F",
-    :size        => 2,
-    :bits        => 16
+    default: 15,
+    default_hex: "\x0F\x00",
+    alt: 14,
+    alt_hex: "\x0E\x00",
+    small: "\x0F",
+    size: 2,
+    bits: 16,
+    error: TypeError
   }
 
   it_behaves_like 'a field', 15, false
   it_behaves_like 'an integer field', int_values
-
 end

--- a/spec/lib/net/ntlm/int32_le_spec.rb
+++ b/spec/lib/net/ntlm/int32_le_spec.rb
@@ -1,17 +1,17 @@
-RSpec.describe Net::NTLM::Int32LE do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Int32LE do
   int_values = {
-      :default     => 252716124,
-      :default_hex => "\x5C\x24\x10\x0f",
-      :alt         => 235938908,
-      :alt_hex     => "\x5C\x24\x10\x0e",
-      :small       => "\x0F\x00",
-      :size        => 4,
-      :bits        => 32
+    default: 252_716_124,
+    default_hex: "\x5C\x24\x10\x0f",
+    alt: 235_938_908,
+    alt_hex: "\x5C\x24\x10\x0e",
+    small: "\x0F\x00",
+    size: 4,
+    bits: 32,
+    error: TypeError
   }
 
-
-  it_behaves_like 'a field', 252716124, false
+  it_behaves_like 'a field', 252_716_124, false
   it_behaves_like 'an integer field', int_values
-
 end

--- a/spec/lib/net/ntlm/int64_le_spec.rb
+++ b/spec/lib/net/ntlm/int64_le_spec.rb
@@ -1,17 +1,17 @@
-RSpec.describe Net::NTLM::Int64LE do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Int64LE do
   int_values = {
-      :default     => 5294967295,
-      :default_hex => [5294967295 & 0x00000000ffffffff, 5294967295 >> 32].pack("V2"),
-      :alt         => 5294967294,
-      :alt_hex     => [5294967294 & 0x00000000ffffffff, 5294967294 >> 32].pack("V2"),
-      :small       => "\x5C\x24\x10\x0f",
-      :size        => 8,
-      :bits        => 64
+    default: 5_294_967_295,
+    default_hex: [5_294_967_295 & 0x00000000ffffffff, 5_294_967_295 >> 32].pack('V2'),
+    alt: 5_294_967_294,
+    alt_hex: [5_294_967_294 & 0x00000000ffffffff, 5_294_967_294 >> 32].pack('V2'),
+    small: "\x5C\x24\x10\x0f",
+    size: 8,
+    bits: 64,
+    error: NoMethodError
   }
 
-
-  it_behaves_like 'a field', 252716124, false
+  it_behaves_like 'a field', 252_716_124, false
   it_behaves_like 'an integer field', int_values
-
 end

--- a/spec/lib/net/ntlm/md4_spec.rb
+++ b/spec/lib/net/ntlm/md4_spec.rb
@@ -1,16 +1,21 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::Md4 do
   describe '.digest' do
+    let(:input) { "\xff".b.freeze }
+
     it 'hashes binary input containing high bytes' do
       # Independently calculated with OpenSSL's legacy MD4 provider.
-      expect(described_class.digest("\xff".b).unpack('H*').first).
-        to eq('82c167af8e345bd055487af8d2b540c9')
+      expect(described_class.digest("\xff".b).unpack1('H*'))
+        .to eq('82c167af8e345bd055487af8d2b540c9')
     end
 
     it 'preserves the caller input and encoding' do
-      input = "\xff".b.freeze
       described_class.digest(input)
-      expect(input).to eq("\xff".b)
-      expect(input.encoding).to eq(Encoding::ASCII_8BIT)
+      aggregate_failures do
+        expect(input).to eq("\xff".b)
+        expect(input.encoding).to eq(Encoding::ASCII_8BIT)
+      end
     end
   end
 end

--- a/spec/lib/net/ntlm/message/type0_spec.rb
+++ b/spec/lib/net/ntlm/message/type0_spec.rb
@@ -1,19 +1,18 @@
-RSpec.describe Net::NTLM::Message::Type0 do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Message::Type0 do
   fields = [
-      { :name => :sign, :class => Net::NTLM::String, :value => Net::NTLM::SSP_SIGN, :active => true },
-      { :name => :type, :class => Net::NTLM::Int32LE, :value => 0, :active => true },
+    { name: :sign, class: Net::NTLM::String, value: Net::NTLM::SSP_SIGN, active: true },
+    { name: :type, class: Net::NTLM::Int32LE, value: 0, active: true }
   ]
-  flags = [
-      :UNICODE,
-      :OEM,
-      :REQUEST_TARGET,
-      :NTLM,
-      :ALWAYS_SIGN,
-      :NTLM2_KEY
+  flags = %i[
+    UNICODE
+    OEM
+    REQUEST_TARGET
+    NTLM
+    ALWAYS_SIGN
+    NTLM2_KEY
   ]
   it_behaves_like 'a fieldset', fields
   it_behaves_like 'a message', flags
-
-
 end

--- a/spec/lib/net/ntlm/message/type1_spec.rb
+++ b/spec/lib/net/ntlm/message/type1_spec.rb
@@ -1,103 +1,116 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::Message::Type1 do
   fields = [
-      { :name => :sign, :class => Net::NTLM::String, :value => Net::NTLM::SSP_SIGN, :active => true },
-      { :name => :type, :class => Net::NTLM::Int32LE, :value => 1, :active => true },
-      { :name => :flag, :class => Net::NTLM::Int32LE, :value =>  Net::NTLM::DEFAULT_FLAGS[:TYPE1], :active => true },
-      { :name => :domain, :class => Net::NTLM::SecurityBuffer, :value => '', :active => true },
-      { :name => :workstation, :class => Net::NTLM::SecurityBuffer, :value =>  Socket.gethostname, :active => true },
-      { :name => :os_version, :class => Net::NTLM::String, :value => '', :active => false },
+    { name: :sign, class: Net::NTLM::String, value: Net::NTLM::SSP_SIGN, active: true },
+    { name: :type, class: Net::NTLM::Int32LE, value: 1, active: true },
+    { name: :flag, class: Net::NTLM::Int32LE, value: Net::NTLM::DEFAULT_FLAGS[:TYPE1], active: true },
+    { name: :domain, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :workstation, class: Net::NTLM::SecurityBuffer, value: Socket.gethostname, active: true },
+    { name: :os_version, class: Net::NTLM::String, value: '', active: false }
   ]
-  flags = [
-      :UNICODE,
-      :OEM,
-      :REQUEST_TARGET,
-      :NTLM,
-      :ALWAYS_SIGN,
-      :NTLM2_KEY
+  flags = %i[
+    UNICODE
+    OEM
+    REQUEST_TARGET
+    NTLM
+    ALWAYS_SIGN
+    NTLM2_KEY
   ]
+  let(:type1_packet) { 'TlRMTVNTUAABAAAAB4IIAAAAAAAgAAAAAAAAACAAAAA=' }
+  let(:deserialized) { Net::NTLM::Message.decode64(type1_packet) }
+
+  # Verifies the parsed flag integer and each expected flag name.
+  def expect_flags(message, value, flags)
+    aggregate_failures do
+      expect(message.flag).to eq(value)
+      flags.each { |flag| expect(message).to have_flag(flag) }
+    end
+  end
+
   it_behaves_like 'a fieldset', fields
   it_behaves_like 'a message', flags
 
-  let(:type1_packet) {"TlRMTVNTUAABAAAAB4IIAAAAAAAgAAAAAAAAACAAAAA="}
-
-  it 'should deserialize' do
-    t1 =  Net::NTLM::Message.decode64(type1_packet)
-    expect(t1.class).to eq(Net::NTLM::Message::Type1)
-    expect(t1.domain).to eq('')
-    expect(t1.flag).to eq(557575)
-    expect(t1.os_version).to eq('')
-    expect(t1.sign).to eq("NTLMSSP\0")
-    expect(t1.type).to eq(1)
-    expect(t1.workstation).to eq('')
+  it 'deserializes the message type' do
+    expect(deserialized.class).to eq(described_class)
   end
 
-  it 'should serialize' do
-    t1 = Net::NTLM::Message::Type1.new
+  it 'deserializes the header fields' do
+    aggregate_failures do
+      expect(deserialized.sign).to eq("NTLMSSP\0")
+      expect(deserialized.type).to eq(1)
+      expect(deserialized.flag).to eq(557_575)
+    end
+  end
+
+  it 'deserializes the payload fields' do
+    aggregate_failures do
+      expect(deserialized.domain).to eq('')
+      expect(deserialized.workstation).to eq('')
+      expect(deserialized.os_version).to eq('')
+    end
+  end
+
+  it 'serializes' do
+    t1 = described_class.new
     t1.workstation = ''
     expect(t1.encode64).to eq(type1_packet)
   end
 
   describe '.parse' do
     subject(:message) { described_class.parse(data) }
+
     # http://davenport.sourceforge.net/ntlm.html#appendixC7
-    context 'NTLM2 Session Response Authentication; NTLM2 Signing and Sealing Using the 128-bit NTLM2 Session Response User Session Key With Key Exchange Negotiated' do
+    context 'NTLM2 Session Response Authentication; NTLM2 Signing and Sealing Using the 128-bit NTLM2 Session Re' \
+        'sponse User Session Key With Key Exchange Negotiated' do
       let(:data) do
         ['4e544c4d5353500001000000b78208e000000000000000000000000000000000'].pack('H*')
       end
 
-      it 'should set the magic' do
+      it 'sets the magic' do
         expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
       end
-      it 'should set the type' do
+
+      it 'sets the type' do
         expect(message.type).to eq(1)
       end
-      it 'should set the flags' do
-        expect(message.flag).to eq(0xe00882b7)
-        expect(message).to have_flag(:UNICODE)
-        expect(message).to have_flag(:OEM)
-        expect(message).to have_flag(:REQUEST_TARGET)
-        expect(message).to have_flag(:SIGN)
-        expect(message).to have_flag(:SEAL)
-        expect(message).to have_flag(:NTLM)
-        expect(message).to have_flag(:ALWAYS_SIGN)
-        expect(message).to have_flag(:NTLM2_KEY)
-        expect(message).to have_flag(:KEY128)
-        expect(message).to have_flag(:KEY_EXCHANGE)
-        expect(message).to have_flag(:KEY56)
-      end
-      it 'should have empty workstation' do
-        expect(message.workstation).to be_empty
-      end
-      it 'should have empty domain' do
-        expect(message.domain).to be_empty
+
+      it 'sets the flags' do
+        expected_flags = %i[UNICODE OEM REQUEST_TARGET SIGN SEAL NTLM ALWAYS_SIGN NTLM2_KEY KEY128 KEY_EXCHANGE KEY56]
+        expect_flags(message, 0xe00882b7, expected_flags)
       end
 
+      it 'has empty workstation' do
+        expect(message.workstation).to be_empty
+      end
+
+      it 'has empty domain' do
+        expect(message.domain).to be_empty
+      end
     end
 
     # http://davenport.sourceforge.net/ntlm.html#appendixC9
     context 'NTLMv2 Authentication; NTLM1 Signing and Sealing Using the 40-bit NTLMv2 User Session Key' do
       let(:data) { ['4e544c4d53535000010000003782000000000000000000000000000000000000'].pack('H*') }
 
-      it 'should set the magic' do
+      it 'sets the magic' do
         expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
       end
-      it 'should set the type' do
+
+      it 'sets the type' do
         expect(message.type).to eq(1)
       end
-      it 'should set the flags' do
-        expect(message.flag).to eq(0x00008237)
-        expect(message).to have_flag(:UNICODE)
-        expect(message).to have_flag(:OEM)
-        expect(message).to have_flag(:REQUEST_TARGET)
-        expect(message).to have_flag(:SIGN)
-        expect(message).to have_flag(:SEAL)
-        expect(message).to have_flag(:NTLM)
-        expect(message).to have_flag(:ALWAYS_SIGN)
+
+      it 'sets the flags' do
+        expected_flags = %i[UNICODE OEM REQUEST_TARGET SIGN SEAL NTLM ALWAYS_SIGN]
+        expect_flags(message, 0x00008237, expected_flags)
       end
-      it 'should have empty workstation' do
+
+      it 'has empty workstation' do
         expect(message.workstation).to be_empty
       end
-      it 'should have empty domain' do
+
+      it 'has empty domain' do
         expect(message.domain).to be_empty
       end
     end
@@ -105,25 +118,25 @@ RSpec.describe Net::NTLM::Message::Type1 do
     context 'NTLMv2 with OS version' do
       let(:data) { ['4e544c4d5353500001000000978208e2000000000000000000000000000000000602f0230000000f'].pack('H*') }
 
-      it 'should set the magic' do
+      it 'sets the magic' do
         expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
       end
-      it 'should set the type' do
+
+      it 'sets the type' do
         expect(message.type).to eq(1)
       end
-      it 'should have empty workstation' do
+
+      it 'has empty workstation' do
         expect(message.workstation).to be_empty
       end
-      it 'should have empty domain' do
+
+      it 'has empty domain' do
         expect(message.domain).to be_empty
       end
 
-      it 'should set OS version info' do
+      it 'sets OS version info' do
         expect(message.os_version).to eq(['0602f0230000000f'].pack('H*'))
       end
-
     end
-
   end
-
 end

--- a/spec/lib/net/ntlm/message/type2_spec.rb
+++ b/spec/lib/net/ntlm/message/type2_spec.rb
@@ -1,92 +1,121 @@
-# encoding: UTF-8
+# frozen_string_literal: true
 
 RSpec.describe Net::NTLM::Message::Type2 do
-
   fields = [
-      { :name => :sign, :class => Net::NTLM::String, :value => Net::NTLM::SSP_SIGN, :active => true },
-      { :name => :type, :class => Net::NTLM::Int32LE, :value => 2, :active => true },
-      { :name => :challenge, :class => Net::NTLM::Int64LE, :value => 0, :active => true },
-      { :name => :context, :class => Net::NTLM::Int64LE, :value => 0, :active => false },
-      { :name => :flag, :class => Net::NTLM::Int32LE, :value =>  Net::NTLM::DEFAULT_FLAGS[:TYPE2], :active => true },
-      { :name => :target_name, :class => Net::NTLM::SecurityBuffer, :value => '', :active => true },
-      { :name => :target_info, :class => Net::NTLM::SecurityBuffer, :value =>  '', :active => false },
-      { :name => :os_version, :class => Net::NTLM::String, :value => '', :active => false },
+    { name: :sign, class: Net::NTLM::String, value: Net::NTLM::SSP_SIGN, active: true },
+    { name: :type, class: Net::NTLM::Int32LE, value: 2, active: true },
+    { name: :challenge, class: Net::NTLM::Int64LE, value: 0, active: true },
+    { name: :context, class: Net::NTLM::Int64LE, value: 0, active: false },
+    { name: :flag, class: Net::NTLM::Int32LE, value: Net::NTLM::DEFAULT_FLAGS[:TYPE2], active: true },
+    { name: :target_name, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :target_info, class: Net::NTLM::SecurityBuffer, value: '', active: false },
+    { name: :os_version, class: Net::NTLM::String, value: '', active: false }
   ]
   flags = [
-      :UNICODE
+    :UNICODE
   ]
+  let(:type3_packet) {
+    'TlRMTVNTUAADAAAAGAAYAEQAAADAAMAAXAAAAAAAAAAcAQAADgAOABwBAAAUABQAKgEAAAAAAAA+AQAABYKKAgAAAADVS27TfQGmWxSSbXm' \
+        'olTUQyxJmD8ISQuBKKHFKC8GksUZISYc8Ps9RAQEAAAAAAAAANasTdCfOAcsSZg/CEkLgAAAAAAIAHABWAEEARwBSAEEATgBUAC0AMg' \
+        'AwADAAOABSADIAAQAcAFYAQQBHAFIAQQBOAFQALQAyADAAMAA4AFIAMgAEABwAdgBhAGcAcgBhAG4AdAAtADIAMAAwADgAUgAyAAMAH' \
+        'AB2AGEAZwByAGEAbgB0AC0AMgAwADAAOABSADIABwAIAGQTHRR0J84BAAAAAAAAAAB2AGEAZwByAGEAbgB0AGsAbwBiAGUALgBsAG8A' \
+        'YwBhAGwA'
+  }
+  let(:type2_packet) {
+    'TlRMTVNTUAACAAAAHAAcADgAAAAFgooCJ+UA1//+ZM4AAAAAAAAAAJAAkABUAAAABgGxHQAAAA9WAEEARwBSAEEATgBUAC0AMgAwADAAOAB' \
+        'SADIAAgAcAFYAQQBHAFIAQQBOAFQALQAyADAAMAA4AFIAMgABABwAVgBBAEcAUgBBAE4AVAAtADIAMAAwADgAUgAyAAQAHAB2AGEAZw' \
+        'ByAGEAbgB0AC0AMgAwADAAOABSADIAAwAcAHYAYQBnAHIAYQBuAHQALQAyADAAMAA4AFIAMgAHAAgAZBMdFHQnzgEAAAAA'
+  }
+  let(:t2) { Net::NTLM::Message.decode64(type2_packet) }
+
+  def rebuilt_t2
+    described_class.new.tap do |msg|
+      %i[challenge context flag os_version sign target_info target_name type].each do |field|
+        msg[field].value = t2[field].value
+      end
+      %i[context target_info os_version].each { |field| msg.enable(field) }
+    end
+  end
+
   it_behaves_like 'a fieldset', fields
   it_behaves_like 'a message', flags
 
-  let(:type2_packet) {"TlRMTVNTUAACAAAAHAAcADgAAAAFgooCJ+UA1//+ZM4AAAAAAAAAAJAAkABUAAAABgGxHQAAAA9WAEEARwBSAEEATgBUAC0AMgAwADAAOABSADIAAgAcAFYAQQBHAFIAQQBOAFQALQAyADAAMAA4AFIAMgABABwAVgBBAEcAUgBBAE4AVAAtADIAMAAwADgAUgAyAAQAHAB2AGEAZwByAGEAbgB0AC0AMgAwADAAOABSADIAAwAcAHYAYQBnAHIAYQBuAHQALQAyADAAMAA4AFIAMgAHAAgAZBMdFHQnzgEAAAAA"}
-  let(:type3_packet) {"TlRMTVNTUAADAAAAGAAYAEQAAADAAMAAXAAAAAAAAAAcAQAADgAOABwBAAAUABQAKgEAAAAAAAA+AQAABYKKAgAAAADVS27TfQGmWxSSbXmolTUQyxJmD8ISQuBKKHFKC8GksUZISYc8Ps9RAQEAAAAAAAAANasTdCfOAcsSZg/CEkLgAAAAAAIAHABWAEEARwBSAEEATgBUAC0AMgAwADAAOABSADIAAQAcAFYAQQBHAFIAQQBOAFQALQAyADAAMAA4AFIAMgAEABwAdgBhAGcAcgBhAG4AdAAtADIAMAAwADgAUgAyAAMAHAB2AGEAZwByAGEAbgB0AC0AMgAwADAAOABSADIABwAIAGQTHRR0J84BAAAAAAAAAAB2AGEAZwByAGEAbgB0AGsAbwBiAGUALgBsAG8AYwBhAGwA"}
+  it 'deserializes the message header' do
+    aggregate_failures do
+      expect(t2.class).to eq(described_class)
+      expect(t2.sign).to eq("NTLMSSP\0")
+      expect(t2.type).to eq(2)
+    end
+  end
 
-  it 'should deserialize' do
-    t2 =  Net::NTLM::Message.decode64(type2_packet)
-    expect(t2.class).to eq(Net::NTLM::Message::Type2)
-    expect(t2.challenge).to eq(14872292244261496103)
-    expect(t2.context).to eq(0)
-    expect(t2.flag).to eq(42631685)
+  it 'deserializes the challenge and flags' do
+    aggregate_failures do
+      expect(t2.challenge).to eq(14_872_292_244_261_496_103)
+      expect(t2.context).to eq(0)
+      expect(t2.flag).to eq(42_631_685)
+    end
+  end
+
+  it 'deserializes the target name' do
+    expect(Net::NTLM::EncodeUtil.decode_utf16le(t2.target_name)).to eq('VAGRANT-2008R2')
+  end
+
+  it 'deserializes the target info' do
+    info = Net::NTLM::EncodeUtil.decode_utf16le(t2.target_info)
+    expect(info).to eq("\u0002\u001CVAGRANT-2008R2\u0001\u001CVAGRANT-2008R2\u0004\u001Cvagrant-2008" \
+      "R2\u0003\u001Cvagrant-2008R2\a\b፤ᐝ❴ǎ\0\0")
+  end
+
+  it 'deserializes the os version' do
     expect(t2.os_version).to eq(['0601b11d0000000f'].pack('H*'))
-    expect(t2.sign).to eq("NTLMSSP\0")
+  end
 
-    t2_target_info = Net::NTLM::EncodeUtil.decode_utf16le(t2.target_info)
-    if RUBY_VERSION == "1.8.7"
-      expect(t2_target_info).to eq("\x02\x1CVAGRANT-2008R2\x01\x1CVAGRANT-2008R2\x04\x1Cvagrant-2008R2\x03\x1Cvagrant-2008R2\a\b\e$(D+&\e(B\0\0")
-    else
-      expect(t2_target_info).to eq("\u0002\u001CVAGRANT-2008R2\u0001\u001CVAGRANT-2008R2\u0004\u001Cvagrant-2008R2\u0003\u001Cvagrant-2008R2\a\b፤ᐝ❴ǎ\0\0")
+  it 'serializes' do
+    expect(rebuilt_t2.encode64).to eq(type2_packet)
+  end
+
+  describe '#response' do
+    let(:t3) do
+      t2.response({ user: 'vagrant', password: 'vagrant', domain: '' },
+                  { ntlmv2: true, workstation: 'kobe.local' })
+    end
+    let(:type3_known) do
+      Net::NTLM::Message.decode64(type3_packet).tap do |known|
+        known.flag = 0x028a8205
+        known.enable(:session_key)
+        known.enable(:flag)
+      end
     end
 
-    expect(Net::NTLM::EncodeUtil.decode_utf16le(t2.target_name)).to eq("VAGRANT-2008R2")
-    expect(t2.type).to eq(2)
-  end
+    it 'generates the expected response fields' do
+      aggregate_failures do
+        expect(t3.domain).to eq(type3_known.domain)
+        expect(t3.flag).to eq(type3_known.flag)
+        expect(t3.sign).to eq("NTLMSSP\0")
+      end
+    end
 
-  it 'should serialize' do
-    source = Net::NTLM::Message.decode64(type2_packet)
+    it 'encodes the workstation, user and session key' do
+      aggregate_failures do
+        expect(t3.workstation).to eq("k\0o\0b\0e\0.\0l\0o\0c\0a\0l\0")
+        expect(t3.user).to eq("v\0a\0g\0r\0a\0n\0t\0")
+        expect(t3.session_key).to eq('')
+      end
+    end
 
-    t2 =  Net::NTLM::Message::Type2.new
-    t2.challenge = source.challenge
-    t2.context = source.context
-    t2.flag = source.flag
-    t2.os_version = source.os_version
-    t2.sign = source.sign
-    t2.target_info = source.target_info
-    t2.target_name = source.target_name
-    t2.type = source.type
-    t2.enable(:context)
-    t2.enable(:target_info)
-    t2.enable(:os_version)
-
-    expect(t2.encode64).to eq(type2_packet)
-  end
-
-  it 'should generate a type 3 response' do
-    t2 = Net::NTLM::Message.decode64(type2_packet)
-
-    type3_known = Net::NTLM::Message.decode64(type3_packet)
-    type3_known.flag = 0x028a8205
-    type3_known.enable(:session_key)
-    type3_known.enable(:flag)
-
-    t3 = t2.response({:user => 'vagrant', :password => 'vagrant', :domain => ''}, {:ntlmv2 => true, :workstation => 'kobe.local'})
-    expect(t3.domain).to eq(type3_known.domain)
-    expect(t3.flag).to eq(type3_known.flag)
-    expect(t3.sign).to eq("NTLMSSP\0")
-    expect(t3.workstation).to eq("k\0o\0b\0e\0.\0l\0o\0c\0a\0l\0")
-    expect(t3.user).to eq("v\0a\0g\0r\0a\0n\0t\0")
-    expect(t3.session_key).to eq('')
-  end
-
-  it 'should upcase domain when provided' do
-    t2 = Net::NTLM::Message.decode64(type2_packet)
-    t3 = t2.response({:user => 'vagrant', :password => 'vagrant', :domain => 'domain'}, {:ntlmv2 => true, :workstation => 'kobe.local'})
-    expect(t3.domain).to eq("D\0O\0M\0A\0I\0N\0")
+    it 'upcases domain when provided' do
+      response = t2.response({ user: 'vagrant', password: 'vagrant', domain: 'domain' },
+                             { ntlmv2: true, workstation: 'kobe.local' })
+      expect(response.domain).to eq("D\0O\0M\0A\0I\0N\0")
+    end
   end
 
   describe '.parse' do
     subject(:message) { described_class.parse(data) }
+
     # http://davenport.sourceforge.net/ntlm.html#appendixC7
-    context 'NTLM2 Session Response Authentication; NTLM2 Signing and Sealing Using the 128-bit NTLM2 Session Response User Session Key With Key Exchange Negotiated' do
+    context 'NTLM2 Session Response Authentication; NTLM2 Signing and Sealing Using the 128-bit NTLM2 Session Re' \
+        'sponse User Session Key With Key Exchange Negotiated' do
       let(:data) do
         [
           '4e544c4d53535000020000000c000c0030000000358289e0677f1c557a5ee96c' \
@@ -96,36 +125,42 @@ RSpec.describe Net::NTLM::Message::Type2 do
           '0000'
         ].pack('H*')
       end
-
-      it 'should set the magic' do
-        expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
-      end
-      it 'should set the type' do
-        expect(message.type).to eq(2)
-      end
-      it 'should set the target name' do
-        # TESTNT
-        expect(message.target_name).to eq(["54004500530054004e005400"].pack('H*'))
-      end
-      it 'should set the flags' do
-        expect(message.flag).to eq(0xe0898235)
-      end
-      it 'should set the challenge' do
-        expect(message.challenge).to eq(0x6ce95e7a551c7f67)
-      end
-      it 'should set an empty context' do
-        expect(message.context).to be_zero
-      end
-      it 'should set target info' do
-        ti = [
+      let(:expected_target_info) do
+        [
           '02000c0054004500530054004e00540001000c004d0045004d00420045005200' \
           '03001e006d0065006d006200650072002e0074006500730074002e0063006f00' \
           '6d0000000000'
         ].pack('H*')
-        expect(message.target_info).to eq(ti)
       end
 
+      it 'sets the magic' do
+        expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
+      end
+
+      it 'sets the type' do
+        expect(message.type).to eq(2)
+      end
+
+      it 'sets the target name' do
+        # TESTNT
+        expect(message.target_name).to eq(['54004500530054004e005400'].pack('H*'))
+      end
+
+      it 'sets the flags' do
+        expect(message.flag).to eq(0xe0898235)
+      end
+
+      it 'sets the challenge' do
+        expect(message.challenge).to eq(0x6ce95e7a551c7f67)
+      end
+
+      it 'sets an empty context' do
+        expect(message.context).to be_zero
+      end
+
+      it 'sets target info' do
+        expect(message.target_info).to eq(expected_target_info)
+      end
     end
   end
-
 end

--- a/spec/lib/net/ntlm/message/type3_spec.rb
+++ b/spec/lib/net/ntlm/message/type3_spec.rb
@@ -1,15 +1,16 @@
-RSpec.describe Net::NTLM::Message::Type3 do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Message::Type3 do
   fields = [
-      { :name => :sign, :class => Net::NTLM::String, :value => Net::NTLM::SSP_SIGN, :active => true },
-      { :name => :type, :class => Net::NTLM::Int32LE, :value => 3, :active => true },
-      { :name => :lm_response, :class => Net::NTLM::SecurityBuffer, :value => '', :active => true },
-      { :name => :ntlm_response, :class => Net::NTLM::SecurityBuffer, :value =>  '', :active => true },
-      { :name => :domain, :class => Net::NTLM::SecurityBuffer, :value =>  '', :active => true },
-      { :name => :user, :class => Net::NTLM::SecurityBuffer, :value =>  '', :active => true },
-      { :name => :workstation, :class => Net::NTLM::SecurityBuffer, :value =>  '', :active => true },
-      { :name => :session_key, :class => Net::NTLM::SecurityBuffer, :value =>  '', :active => false },
-      { :name => :flag, :class => Net::NTLM::Int32LE, :value =>  0, :active => false },
+    { name: :sign, class: Net::NTLM::String, value: Net::NTLM::SSP_SIGN, active: true },
+    { name: :type, class: Net::NTLM::Int32LE, value: 3, active: true },
+    { name: :lm_response, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :ntlm_response, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :domain, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :user, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :workstation, class: Net::NTLM::SecurityBuffer, value: '', active: true },
+    { name: :session_key, class: Net::NTLM::SecurityBuffer, value: '', active: false },
+    { name: :flag, class: Net::NTLM::Int32LE, value: 0, active: false }
   ]
   flags = []
   it_behaves_like 'a fieldset', fields
@@ -40,19 +41,8 @@ RSpec.describe Net::NTLM::Message::Type3 do
       end
 
       let(:server_challenge) { ['f588469dc96fe809'].pack('H*') }
-
-      it 'should set the magic' do
-        expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
-      end
-      it 'should set the type' do
-        expect(message.type).to eq(3)
-      end
-      it 'should set the LM response' do
-        lm_response = ['ced203d860b80c7350050754b238202a8c1c63134f0ae0f0'].pack('H*')
-        expect(message.lm_response).to eq(lm_response)
-      end
-      it 'should set the NTLM response' do
-        ntlm_response = [
+      let(:expected_ntlm_response) do
+        [
           '86a3fb147e8b2f9fde3ef1b1b43c83dc010100000000000080512dba020ed001' \
           '1c5bc2c8339fd29a0000000002001e00570049004e002d00420035004a004e00' \
           '330052004800470046003300310001001e00570049004e002d00420035004a00' \
@@ -61,58 +51,72 @@ RSpec.describe Net::NTLM::Message::Type3 do
           '35004a004e00330052004800470046003300310007000800a209e5ba020ed001' \
           '00000000'
         ].pack('H*')
-        expect(message.ntlm_response).to eq(ntlm_response)
       end
-      it 'should set the user' do
+
+      it 'sets the magic' do
+        expect(message.sign).to eql(Net::NTLM::SSP_SIGN)
+      end
+
+      it 'sets the type' do
+        expect(message.type).to eq(3)
+      end
+
+      it 'sets the LM response' do
+        lm_response = ['ced203d860b80c7350050754b238202a8c1c63134f0ae0f0'].pack('H*')
+        expect(message.lm_response).to eq(lm_response)
+      end
+
+      it 'sets the NTLM response' do
+        expect(message.ntlm_response).to eq(expected_ntlm_response)
+      end
+
+      it 'sets the user' do
         # administrator
         user = ['610064006d0069006e006900730074007200610074006f007200'].pack('H*')
         expect(message.user).to eq(user)
       end
-      it 'should set the domain' do
+
+      it 'sets the domain' do
         # WORKGROUP
         domain = ['57004f0052004b00470052004f0055005000'].pack('H*')
         expect(message.domain).to eq(domain)
       end
-      it 'should set the workstation' do
+
+      it 'sets the workstation' do
         # AUS-LEET-1031
         workstation = ['4100550053002d004c004500450054002d003100300033003100'].pack('H*')
         expect(message.workstation).to eq(workstation)
       end
-      it 'should set the session key' do
+
+      it 'sets the session key' do
         session_key = ['7036615cd6d9b19a685ded4312311cd7'].pack('H*')
         expect(message.session_key).to eq(session_key)
       end
 
-      it 'should set the flags' do
+      it 'sets the flags' do
         expect(message.flag).to eq(0x60088215)
       end
 
-      it 'should NOT set the OS version structure' do
+      it 'does not set the OS version structure' do
         expect(message.os_version).to be_nil
       end
 
-      describe '#blank_password?' do
-        it 'should be true' do
-          expect(message.blank_password?(server_challenge)).to be true
-        end
+      it '#blank_password? is true' do
+        expect(message.blank_password?(server_challenge)).to be true
       end
 
       it 'rejects a non-empty password for an empty-password response' do
         expect(message.password?('test1234', server_challenge)).to be false
       end
 
-      describe '#ntlm_version' do
-        let(:ver) { message.ntlm_version }
-        it 'should be :ntlmv2' do
-          expect(ver).to eq(:ntlmv2)
-        end
+      it '#ntlm_version is :ntlmv2' do
+        expect(message.ntlm_version).to eq(:ntlmv2)
       end
-
     end
 
     # http://davenport.sourceforge.net/ntlm.html#appendixC7
-    context 'NTLM2 Session Response Authentication; NTLM2 Signing and Sealing Using the 128-bit NTLM2 Session Response User Session Key With Key Exchange Negotiated' do
-
+    context 'NTLM2 Session Response Authentication; NTLM2 Signing and Sealing Using the 128-bit NTLM2 Session Re' \
+        'sponse User Session Key With Key Exchange Negotiated' do
       let(:data) do
         [
           '4e544c4d5353500003000000180018006000000018001800780000000c000c00' \
@@ -123,71 +127,64 @@ RSpec.describe Net::NTLM::Message::Type3 do
         ].pack('H*')
       end
 
-      it 'should set the LM response' do
+      let(:server_challenge) { ['677f1c557a5ee96c'].pack('H*') }
+
+      it 'sets the LM response' do
         lm_response = ['404d1b6f6915258000000000000000000000000000000000'].pack('H*')
         expect(message.lm_response).to eq(lm_response)
       end
-      it 'should set the NTLM response' do
-        ntlm_response = [ 'ea8cc49f24da157f13436637f77693d8b992d619e584c7ee' ].pack('H*')
+
+      it 'sets the NTLM response' do
+        ntlm_response = ['ea8cc49f24da157f13436637f77693d8b992d619e584c7ee'].pack('H*')
         expect(message.ntlm_response).to eq(ntlm_response)
       end
-      it 'should set the domain' do
+
+      it 'sets the domain' do
         # TESTNT
         domain = ['54004500530054004e005400'].pack('H*')
         expect(message.domain).to eq(domain)
       end
-      it 'should set the user' do
+
+      it 'sets the user' do
         # test
         user = ['7400650073007400'].pack('H*')
         expect(message.user).to eq(user)
       end
-      it 'should set the workstation' do
+
+      it 'sets the workstation' do
         # MEMBER
         workstation = ['4d0045004d00420045005200'].pack('H*')
         expect(message.workstation).to eq(workstation)
       end
-      it 'should set the session key' do
+
+      it 'sets the session key' do
         session_key = ['727a5240822ec7af4e9100c43e6fee7f'].pack('H*')
         expect(message.session_key).to eq(session_key)
       end
 
-      let(:server_challenge) { ['677f1c557a5ee96c'].pack('H*') }
-      describe '#password?' do
-        it 'should be true for "test1234"' do
-          expect(message.password?('test1234', server_challenge)).to be true
-        end
-      end
-      describe '#blank_password?' do
-        it 'should be false' do
-          expect(message.blank_password?(server_challenge)).to be false
-        end
+      it '#password? is true for "test1234"' do
+        expect(message.password?('test1234', server_challenge)).to be true
       end
 
-      describe '#ntlm_version' do
-        let(:ver) { message.ntlm_version }
-        it 'should be :ntlm2_session' do
-          expect(ver).to eq(:ntlm2_session)
-        end
+      it '#blank_password? is false' do
+        expect(message.blank_password?(server_challenge)).to be false
       end
 
+      it '#ntlm_version is :ntlm2_session' do
+        expect(message.ntlm_version).to eq(:ntlm2_session)
+      end
     end
 
     # http://davenport.sourceforge.net/ntlm.html#appendixC9
     context 'NTLMv2 Authentication; NTLM1 Signing and Sealing Using the 40-bit NTLMv2 User Session Key' do
       let(:server_challenge) { ['0033b02d17275b77'].pack('H*') }
-
-      describe '#password?' do
-        it 'accepts the known fixture password' do
-          expect(message.password?('test1234', server_challenge)).to be true
-        end
-
-        it 'rejects an incorrect password' do
-          expect(message.password?('wrong', server_challenge)).to be false
-        end
-
-        it 'rejects an empty password' do
-          expect(message.blank_password?(server_challenge)).to be false
-        end
+      let(:expected_ntlm_response) do
+        [
+          'f77c67dad00b93216242b197fe6addfa0101000000000000502db638677bc301' \
+          'f2e6329726c598e80000000002000c0054004500530054004e00540001000c00' \
+          '4d0045004d0042004500520003001e006d0065006d006200650072002e007400' \
+          '6500730074002e0063006f006d000000000000000000'
+        ].pack 'H*'
       end
 
       let(:data) do
@@ -203,56 +200,60 @@ RSpec.describe Net::NTLM::Message::Type3 do
         ].pack 'H*'
       end
 
-      it 'should set the NTLM response' do
-        ntlm_response = [
-          'f77c67dad00b93216242b197fe6addfa0101000000000000502db638677bc301' \
-          'f2e6329726c598e80000000002000c0054004500530054004e00540001000c00' \
-          '4d0045004d0042004500520003001e006d0065006d006200650072002e007400' \
-          '6500730074002e0063006f006d000000000000000000'
-        ].pack 'H*'
-        expect(message.ntlm_response).to eq(ntlm_response)
+      it '#password? accepts the known fixture password' do
+        expect(message.password?('test1234', server_challenge)).to be true
       end
 
-      it 'should set the domain' do
+      it '#password? rejects an incorrect password' do
+        expect(message.password?('wrong', server_challenge)).to be false
+      end
+
+      it '#blank_password? rejects an empty password' do
+        expect(message.blank_password?(server_challenge)).to be false
+      end
+
+      it 'sets the NTLM response' do
+        expect(message.ntlm_response).to eq(expected_ntlm_response)
+      end
+
+      it 'sets the domain' do
         # TESTNT
         domain = ['54004500530054004e005400'].pack('H*')
         expect(message.domain).to eq(domain)
       end
-      it 'should set the user' do
+
+      it 'sets the user' do
         # test
         user = ['7400650073007400'].pack('H*')
         expect(message.user).to eq(user)
       end
-      it 'should set the workstation' do
+
+      it 'sets the workstation' do
         # MEMBER
         workstation = ['4d0045004d00420045005200'].pack('H*')
         expect(message.workstation).to eq(workstation)
       end
 
-      describe '#ntlm_version' do
-        let(:ver) { message.ntlm_version }
-        it 'should be :ntlmv2' do
-          expect(ver).to eq(:ntlmv2)
-        end
+      it '#ntlm_version is :ntlmv2' do
+        expect(message.ntlm_version).to eq(:ntlmv2)
       end
-
     end
-
   end
 
   describe '#password? with serialized NTLMv2 responses' do
+    subject(:message) do
+      described_class.parse(type2.response(
+        { user: 'victim', domain: 'CORP', password: password },
+        { ntlmv2: true, client_challenge: 0x1122334455667788, timestamp: 0 }
+      ).serialize)
+    end
+
     let(:type2) do
       Net::NTLM::Message::Type2.new.tap do |message|
         message.challenge = 0x0123456789abcdef
       end
     end
     let(:server_challenge) { Net::NTLM.pack_int64le(type2.challenge) }
-    subject(:message) do
-      described_class.parse(type2.response(
-        { :user => 'victim', :domain => 'CORP', :password => password },
-        { :ntlmv2 => true, :client_challenge => 0x1122334455667788, :timestamp => 0 }
-      ).serialize)
-    end
 
     ['secret', 'odd', "p\u00e4ss\u5bc6\u7801\u{1f512}", ''].each do |password|
       context "with password #{password.inspect}" do
@@ -292,18 +293,20 @@ RSpec.describe Net::NTLM::Message::Type3 do
   end
 
   describe '#serialize' do
+    subject(:message) { described_class.create(opts) }
+
     context 'when the username contains non-ASCI characters' do
       let(:t3) {
         t2 = Net::NTLM::Message::Type2.new
         t2.response(
           {
-            :user => 'Hélène',
-            :password => '123456',
-            :domain => ''
+            user: 'Hélène',
+            password: '123456',
+            domain: ''
           },
           {
-            :ntlmv2 => true,
-            :workstation => 'testlab.local'
+            ntlmv2: true,
+            workstation: 'testlab.local'
           }
         )
       }
@@ -313,21 +316,23 @@ RSpec.describe Net::NTLM::Message::Type3 do
       end
     end
 
-    subject(:message) { described_class.create(opts) }
     context 'with the UNICODE flag set' do
-      let(:opts) { {lm_response: "\x00".b, ntlm_response: '', domain: '', workstation: '', user: '', flag: Net::NTLM::DEFAULT_FLAGS[:TYPE3] | Net::NTLM::FLAGS[:UNICODE] } }
+      let(:opts) {
+        { lm_response: "\x00".b, ntlm_response: '', domain: '', workstation: '', user: '',
+       flag: Net::NTLM::DEFAULT_FLAGS[:TYPE3] | Net::NTLM::FLAGS[:UNICODE] }
+      }
 
-      it 'should pad the domain field to a multiple of 2' do
+      it 'pads the domain field to a multiple of 2' do
         message.serialize
         expect(message[:domain][:offset].value % 2).to eq 0
       end
 
-      it 'should pad the user field to a multiple of 2' do
+      it 'pads the user field to a multiple of 2' do
         message.serialize
         expect(message[:user][:offset].value % 2).to eq 0
       end
 
-      it 'should pad the workstation field to a multiple of 2' do
+      it 'pads the workstation field to a multiple of 2' do
         message.serialize
         expect(message[:workstation][:offset].value % 2).to eq 0
       end

--- a/spec/lib/net/ntlm/message_spec.rb
+++ b/spec/lib/net/ntlm/message_spec.rb
@@ -1,15 +1,15 @@
-RSpec.describe Net::NTLM::Message do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::Message do
   fields = []
-  flags = [
-      :UNICODE,
-      :OEM,
-      :REQUEST_TARGET,
-      :NTLM,
-      :ALWAYS_SIGN,
-      :NTLM2_KEY
+  flags = %i[
+    UNICODE
+    OEM
+    REQUEST_TARGET
+    NTLM
+    ALWAYS_SIGN
+    NTLM2_KEY
   ]
   it_behaves_like 'a fieldset', fields
   it_behaves_like 'a message', flags
-
 end

--- a/spec/lib/net/ntlm/security_buffer_spec.rb
+++ b/spec/lib/net/ntlm/security_buffer_spec.rb
@@ -1,62 +1,67 @@
-RSpec.describe Net::NTLM::SecurityBuffer do
+# frozen_string_literal: true
 
+RSpec.describe Net::NTLM::SecurityBuffer do
   fields = [
-      { :name => :length, :class => Net::NTLM::Int16LE, :value => 0, :active => true },
-      { :name => :allocated, :class => Net::NTLM::Int16LE, :value => 0, :active => true },
-      { :name => :offset, :class => Net::NTLM::Int32LE, :value => 0, :active => true },
+    { name: :length, class: Net::NTLM::Int16LE, value: 0, active: true },
+    { name: :allocated, class: Net::NTLM::Int16LE, value: 0, active: true },
+    { name: :offset, class: Net::NTLM::Int32LE, value: 0, active: true }
   ]
+
+  subject(:domain_security_buffer) do
+    described_class.new({
+      value: 'WORKSTATION',
+      active: true
+    })
+  end
 
   it_behaves_like 'a fieldset', fields
   it_behaves_like 'a field', 'WORKSTATION', true
 
-
-  subject(:domain_security_buffer) do
-    Net::NTLM::SecurityBuffer.new({
-        :value => 'WORKSTATION',
-        :active => true
-    })
-  end
-
   context 'when setting the value directly' do
-    before(:each) do
+    before do
       domain_security_buffer.value = 'DOMAIN1'
     end
-    it 'should change the value' do
+
+    it 'changes the value' do
       expect(domain_security_buffer.value).to eq('DOMAIN1')
     end
 
-    it 'should adjust the length field to the size of the new value' do
+    it 'adjusts the length field to the size of the new value' do
       expect(domain_security_buffer.length).to eq(7)
     end
 
-    it 'should adjust the allocated field to the size of the new value' do
+    it 'adjusts the allocated field to the size of the new value' do
       expect(domain_security_buffer.allocated).to eq(7)
     end
   end
 
-  context '#data_size' do
-    it 'should return the size of the value if active' do
+  describe '#data_size' do
+    it 'returns the size of the value if active' do
       expect(domain_security_buffer.data_size).to eq(11)
     end
 
-    it 'should return 0 if inactive' do
+    it 'returns 0 if inactive' do
       domain_security_buffer.active = false
       expect(domain_security_buffer.data_size).to eq(0)
     end
   end
 
-  context '#parse' do
-    it 'should read in a properly formatted string' do
+  describe '#parse' do
+    let(:string_to_parse) do
       # Length of the string is 8
       length = "\x08\x00"
       # Space allocated is 8
       allocated = "\x08\x00"
       # The offset that the actual value begins at is also 8
       offset = "\x08\x00\x00\x00"
-      string_to_parse = "#{length}#{allocated}#{offset}FooBarBaz"
-      expect(domain_security_buffer.parse(string_to_parse)).to eq(8)
-      expect(domain_security_buffer.value).to eq('FooBarBa')
+      "#{length}#{allocated}#{offset}FooBarBaz"
     end
 
+    it 'reads in a properly formatted string' do
+      aggregate_failures do
+        expect(domain_security_buffer.parse(string_to_parse)).to eq(8)
+        expect(domain_security_buffer.value).to eq('FooBarBa')
+      end
+    end
   end
 end

--- a/spec/lib/net/ntlm/string_spec.rb
+++ b/spec/lib/net/ntlm/string_spec.rb
@@ -1,70 +1,78 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::String do
+  let(:inactive) {
+    described_class.new({
+      value: 'Test',
+      active: false,
+      size: 4
+    })
+  }
+  let(:active) {
+    described_class.new({
+      value: 'Test',
+      active: true,
+      size: 4
+    })
+  }
 
   it_behaves_like 'a field', 'Foo', false
 
-  let(:active) {
-    Net::NTLM::String.new({
-        :value  => 'Test',
-        :active => true,
-        :size   => 4
-    })
-  }
-
-  let(:inactive) {
-    Net::NTLM::String.new({
-        :value  => 'Test',
-        :active => false,
-        :size   => 4
-    })
-  }
-
-  context '#serialize' do
-    it 'should return the value when active' do
+  describe '#serialize' do
+    it 'returns the value when active' do
       expect(active.serialize).to eq('Test')
     end
 
-    it 'should return an empty string when inactive' do
+    it 'returns an empty string when inactive' do
       expect(inactive.serialize).to eq('')
     end
 
-    it 'should coerce non-string values into strings' do
+    it 'coerces non-string values into strings' do
       active.value = 15
       expect(active.serialize).to eq('15')
     end
 
-    it 'should return empty string on a nil' do
+    it 'returns empty string on a nil' do
       active.value = nil
       expect(active.serialize).to eq('')
     end
   end
 
-  context '#value=' do
-    it 'should set active to false if it empty' do
+  describe '#value=' do
+    it 'sets active to false if it empty' do
       active.value = ''
-      expect(active.active).to eq(false)
+      expect(active.active).to be(false)
     end
 
-    it 'should adjust the size based on the value set' do
-      expect(active.size).to eq(4)
-      active.value = 'Foobar'
-      expect(active.size).to eq(6)
+    it 'adjusts the size based on the value set' do
+      aggregate_failures do
+        expect(active.size).to eq(4)
+        active.value = 'Foobar'
+        expect(active.size).to eq(6)
+      end
     end
   end
 
-  context '#parse' do
-    it 'should read in a string of the proper size' do
-      expect(active.parse('tseT')).to eq(4)
-      expect(active.value).to eq('tseT')
+  describe '#parse' do
+    it 'reads in a string of the proper size' do
+      aggregate_failures do
+        expect(active.parse('tseT')).to eq(4)
+        expect(active.value).to eq('tseT')
+      end
     end
 
-    it 'should not read in a string that is too small' do
-      expect(active.parse('B')).to eq(0)
-      expect(active.value).to eq('Test')
+    it 'does not read in a string that is too small' do
+      aggregate_failures do
+        expect(active.parse('B')).to eq(0)
+        expect(active.value).to eq('Test')
+      end
     end
 
-    it 'should be able to read from an offset and only for the given size' do
-      expect(active.parse('FooBarBaz',3)).to eq(4)
-      expect(active.value).to eq('BarB')
+    it 'is able to read from an offset and only for the given size' do
+      aggregate_failures do
+        expect(active.parse('FooBarBaz', 3)).to eq(4)
+        expect(active.value).to eq('BarB')
+      end
     end
   end
 end

--- a/spec/lib/net/ntlm/target_info_spec.rb
+++ b/spec/lib/net/ntlm/target_info_spec.rb
@@ -1,74 +1,64 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM::TargetInfo do
-  let(:key1) { Net::NTLM::TargetInfo::MSV_AV_NB_COMPUTER_NAME }
-  let(:value1) { 'some data' }
-  let(:key2) { Net::NTLM::TargetInfo::MSV_AV_NB_DOMAIN_NAME }
-  let(:value2) { 'some other data' }  
+  subject(:target_info) { described_class.new(data) }
+
+  let(:computer_name_key) { Net::NTLM::TargetInfo::MSV_AV_NB_COMPUTER_NAME }
+  let(:domain_name_key) { Net::NTLM::TargetInfo::MSV_AV_NB_DOMAIN_NAME }
   let(:data) do
-    dt = key1.dup
-    dt << [value1.length].pack('S')
-    dt << value1
-    dt << key2.dup
-    dt << [value2.length].pack('S')
-    dt << value2
-    dt << Net::NTLM::TargetInfo::MSV_AV_EOL
-    dt << [0].pack('S')
+    target_data({ computer_name_key => 'some data', domain_name_key => 'some other data' })
+  end
+
+  def target_data(pairs, terminated: true)
+    dt = +''
+    pairs.each do |key, value|
+      dt << key
+      dt << [value.length].pack('S')
+      dt << value
+    end
+    dt << Net::NTLM::TargetInfo::MSV_AV_EOL << [0].pack('S') if terminated
     dt.force_encoding(Encoding::ASCII_8BIT)
   end
 
-  subject { Net::NTLM::TargetInfo.new(data) }
-
   describe 'invalid data' do
-
     context 'invalid pair id' do
       let(:data) { "\xFF\x00" }
 
       it 'returns an error' do
-        expect{subject}.to raise_error Net::NTLM::InvalidTargetDataError
-      end    
+        expect { target_info }.to raise_error Net::NTLM::InvalidTargetDataError
+      end
     end
   end
 
   describe '#av_pairs' do
-
     it 'returns the pair values with the given keys' do
-      expect(subject.av_pairs[key1]).to eq value1
-      expect(subject.av_pairs[key2]).to eq value2
+      aggregate_failures do
+        expect(target_info.av_pairs[computer_name_key]).to eq 'some data'
+        expect(target_info.av_pairs[domain_name_key]).to eq 'some other data'
+      end
     end
 
-    context "target data is nil" do
-      subject { Net::NTLM::TargetInfo.new(nil) }
+    context 'target data is nil' do
+      subject(:target_info) { described_class.new(nil) }
 
-      it 'returns the pair values with the given keys' do
-        expect(subject.av_pairs).to be_empty
+      it 'returns an empty hash' do
+        expect(target_info.av_pairs).to be_empty
       end
     end
   end
 
   describe '#to_s' do
     let(:data) do
-      dt = key1.dup
-      dt << [value1.length].pack('S')
-      dt << value1
-      dt << key2.dup
-      dt << [value2.length].pack('S')
-      dt << value2
-      dt.force_encoding(Encoding::ASCII_8BIT)
+      target_data({ computer_name_key => 'some data', domain_name_key => 'some other data' }, terminated: false)
     end
-    let(:new_key) { Net::NTLM::TargetInfo::MSV_AV_CHANNEL_BINDINGS }
-    let(:new_value) { 'bindings' }
     let(:new_data) do
-      dt = data
-      dt << new_key
-      dt << [new_value.length].pack('S')
-      dt << new_value
-      dt << Net::NTLM::TargetInfo::MSV_AV_EOL
-      dt << [0].pack('S')
-      dt.force_encoding(Encoding::ASCII_8BIT)
+      target_data({ computer_name_key => 'some data', domain_name_key => 'some other data',
+                    Net::NTLM::TargetInfo::MSV_AV_CHANNEL_BINDINGS => 'bindings' })
     end
 
     it 'returns bytes with any new data added' do
-      subject.av_pairs[new_key] = new_value
-      expect(subject.to_s).to eq new_data
+      target_info.av_pairs[Net::NTLM::TargetInfo::MSV_AV_CHANNEL_BINDINGS] = 'bindings'
+      expect(target_info.to_s).to eq new_data
     end
   end
 end

--- a/spec/lib/net/ntlm/version_spec.rb
+++ b/spec/lib/net/ntlm/version_spec.rb
@@ -1,26 +1,28 @@
+# frozen_string_literal: true
+
 require File.expand_path("#{File.dirname(__FILE__)}/../../../../lib/net/ntlm/version")
 
 RSpec.describe Net::NTLM::VERSION do
-
-  it 'should contain an integer value for Major Version' do
-    expect(Net::NTLM::VERSION::MAJOR).to be_an Integer
+  let(:expected_string) do
+    [described_class::MAJOR, described_class::MINOR, described_class::TINY].join('.')
   end
 
-  it 'should contain an integer value for Minor Version' do
-    expect(Net::NTLM::VERSION::MINOR).to be_an Integer
+  it 'contains an integer value for Major Version' do
+    expect(described_class::MAJOR).to be_an Integer
   end
 
-  it 'should contain an integer value for Patch Version' do
-    expect(Net::NTLM::VERSION::TINY).to be_an Integer
+  it 'contains an integer value for Minor Version' do
+    expect(described_class::MINOR).to be_an Integer
   end
 
-  it 'should contain an aggregate version string' do
-    string = [
-        Net::NTLM::VERSION::MAJOR,
-        Net::NTLM::VERSION::MINOR,
-        Net::NTLM::VERSION::TINY
-    ].join('.')
-    expect(Net::NTLM::VERSION::STRING).to be_a String
-    expect(Net::NTLM::VERSION::STRING).to eq(string)
+  it 'contains an integer value for Patch Version' do
+    expect(described_class::TINY).to be_an Integer
+  end
+
+  it 'contains an aggregate version string' do
+    aggregate_failures do
+      expect(described_class::STRING).to be_a String
+      expect(described_class::STRING).to eq(expected_string)
+    end
   end
 end

--- a/spec/lib/net/ntlm_spec.rb
+++ b/spec/lib/net/ntlm_spec.rb
@@ -1,133 +1,126 @@
+# frozen_string_literal: true
+
 RSpec.describe Net::NTLM do
-  let(:passwd) {"SecREt01"}
-  let(:user) {"user"}
-  let(:domain) {"DOMAIN"}
-  let(:challenge) {["0123456789abcdef"].pack("H*")}
-  let(:client_ch) {["ffffff0011223344"].pack("H*")}
-  let(:timestamp) {1055844000}
-  let(:trgt_info) {[
-      "02000c0044004f004d00410049004e00" +
-      "01000c00530045005200560045005200" +
-      "0400140064006f006d00610069006e00" +
-      "2e0063006f006d000300220073006500" +
-      "72007600650072002e0064006f006d00" +
-      "610069006e002e0063006f006d000000" +
-      "0000"
-  ].pack("H*")}
-  let(:padded_pwd) { passwd.upcase.ljust(14, "\0")}
-  let(:keys) { Net::NTLM.gen_keys(padded_pwd)}
+  let(:passwd) { 'SecREt01' }
+  let(:user) { 'user' }
+  let(:domain) { 'DOMAIN' }
+  let(:challenge) { ['0123456789abcdef'].pack('H*') }
+  let(:client_ch) { ['ffffff0011223344'].pack('H*') }
 
-  it 'should convert a value to 64-bit LE Integer' do
-    expect(Net::NTLM.pack_int64le(42)).to eq("\x2A\x00\x00\x00\x00\x00\x00\x00")
+  it 'converts a value to 64-bit LE Integer' do
+    expect(described_class.pack_int64le(42)).to eq("\x2A\x00\x00\x00\x00\x00\x00\x00")
   end
 
-  it 'should split a string into an array of slices, 7 chars or less' do
-    expect(Net::NTLM.split7("HelloWorld!")).to eq([ 'HelloWo', 'rld!'])
+  it 'splits a string into an array of slices, 7 chars or less' do
+    expect(described_class.split7('HelloWorld!')).to eq(['HelloWo', 'rld!'])
   end
 
-  it 'should generate DES keys from the supplied string' do
-    first_key = ["52a2516b252a5161"].pack('H*')
-    second_key = ["3180010101010101"].pack('H*')
-    expect(Net::NTLM.gen_keys(padded_pwd)).to eq([first_key, second_key])
+  it 'generates DES keys from the supplied string' do
+    first_key = ['52a2516b252a5161'].pack('H*')
+    second_key = ['3180010101010101'].pack('H*')
+    expect(described_class.gen_keys(passwd.upcase.ljust(14, "\0"))).to eq([first_key, second_key])
   end
 
-  it 'should encrypt the string with DES for each key supplied' do
-    first_crypt = ["ff3750bcc2b22412"].pack('H*')
-    second_crypt = ["c2265b23734e0dac"].pack('H*')
-    expect(Net::NTLM::apply_des(Net::NTLM::LM_MAGIC, keys)).to eq([first_crypt, second_crypt])
+  it 'encrypts the string with DES for each key supplied' do
+    keys = described_class.gen_keys(passwd.upcase.ljust(14, "\0"))
+    first_crypt = ['ff3750bcc2b22412'].pack('H*')
+    second_crypt = ['c2265b23734e0dac'].pack('H*')
+    expect(described_class.apply_des(Net::NTLM::LM_MAGIC, keys)).to eq([first_crypt, second_crypt])
   end
 
-  it 'should generate an lm_hash' do
-    expect(Net::NTLM::lm_hash(passwd)).to eq(["ff3750bcc2b22412c2265b23734e0dac"].pack("H*"))
+  it 'generates an lm_hash' do
+    expect(described_class.lm_hash(passwd)).to eq(['ff3750bcc2b22412c2265b23734e0dac'].pack('H*'))
   end
 
-  it 'should generate an ntlm_hash' do
-    expect(Net::NTLM::ntlm_hash(passwd)).to eq(["cd06ca7c7e10c99b1d33b7485a2ed808"].pack("H*"))
+  it 'generates an ntlm_hash' do
+    expect(described_class.ntlm_hash(passwd)).to eq(['cd06ca7c7e10c99b1d33b7485a2ed808'].pack('H*'))
   end
 
-  it 'should generate an ntlmv2_hash' do
-    expect(Net::NTLM::ntlmv2_hash(user, passwd, domain)).to eq(["04b8e0ba74289cc540826bab1dee63ae"].pack("H*"))
+  it 'generates an ntlmv2_hash' do
+    expect(described_class.ntlmv2_hash(user, passwd, domain)).to eq(['04b8e0ba74289cc540826bab1dee63ae'].pack('H*'))
   end
 
   context 'when a user passes an NTLM hash for pass-the-hash' do
     let(:passwd) { Net::NTLM::EncodeUtil.encode_utf16le('ff3750bcc2b22412c2265b23734e0dac:cd06ca7c7e10c99b1d33b7485a2ed808') }
 
-    it 'should return the correct ntlmv2 hash' do
-      expect(Net::NTLM::ntlmv2_hash(user, passwd, domain)).to eq(["04b8e0ba74289cc540826bab1dee63ae"].pack("H*"))
+    it 'returns the correct ntlmv2 hash' do
+      expect(described_class.ntlmv2_hash(user, passwd, domain)).to eq(['04b8e0ba74289cc540826bab1dee63ae'].pack('H*'))
     end
   end
 
   context 'when the username contains non-ASCI characters' do
     let(:user) { 'юзер' }
 
-    it 'should return the correct ntlmv2 hash' do
-      expect(Net::NTLM::ntlmv2_hash(user, passwd, domain, { unicode: true })).to eq(["a0f4b914a37faeaee884b6b04a20faf0"].pack("H*"))
+    it 'returns the correct ntlmv2 hash' do
+      expect(described_class.ntlmv2_hash(user, passwd, domain,
+                                         { unicode: true })).to eq(['a0f4b914a37faeaee884b6b04a20faf0'].pack('H*'))
     end
   end
 
-  it 'should generate an lm_response' do
-    expect(Net::NTLM::lm_response(
-        {
-            :lm_hash => Net::NTLM::lm_hash(passwd),
-            :challenge => challenge
-        }
-    )).to eq(["c337cd5cbd44fc9782a667af6d427c6de67c20c2d3e77c56"].pack("H*"))
+  it 'generates an lm_response' do
+    args = { lm_hash: described_class.lm_hash(passwd), challenge: challenge }
+    expected = ['c337cd5cbd44fc9782a667af6d427c6de67c20c2d3e77c56'].pack('H*')
+    expect(described_class.lm_response(args)).to eq(expected)
   end
 
-  it 'should generate an ntlm_response' do
-    ntlm_hash = Net::NTLM::ntlm_hash(passwd)
-    expect(Net::NTLM::ntlm_response(
-        {
-            :ntlm_hash => ntlm_hash,
-            :challenge => challenge
-        }
-    )).to eq(["25a98c1c31e81847466b29b2df4680f39958fb8c213a9cc6"].pack("H*"))
+  it 'generates an ntlm_response' do
+    args = { ntlm_hash: described_class.ntlm_hash(passwd), challenge: challenge }
+    expected = ['25a98c1c31e81847466b29b2df4680f39958fb8c213a9cc6'].pack('H*')
+    expect(described_class.ntlm_response(args)).to eq(expected)
   end
 
-  it 'should generate a lvm2_response' do
-    expect(Net::NTLM::lmv2_response(
-        {
-            :ntlmv2_hash => Net::NTLM::ntlmv2_hash(user, passwd, domain),
-            :challenge => challenge
-        },
-        { :client_challenge => client_ch }
-    )).to eq(["d6e6152ea25d03b7c6ba6629c2d6aaf0ffffff0011223344"].pack("H*"))
+  it 'generates a lvm2_response' do
+    args = { ntlmv2_hash: described_class.ntlmv2_hash(user, passwd, domain), challenge: challenge }
+    opts = { client_challenge: client_ch }
+    expected = ['d6e6152ea25d03b7c6ba6629c2d6aaf0ffffff0011223344'].pack('H*')
+    expect(described_class.lmv2_response(args, opts)).to eq(expected)
   end
 
-  it 'should generate a ntlmv2_response' do
-    expect(Net::NTLM::ntlmv2_response(
-        {
-            :ntlmv2_hash => Net::NTLM::ntlmv2_hash(user, passwd, domain),
-            :challenge => challenge,
-            :target_info => trgt_info
-        },
-        {
-            :timestamp => timestamp,
-            :client_challenge => client_ch
-        }
-    )).to eq([
-        "cbabbca713eb795d04c97abc01ee4983" +
-        "01010000000000000090d336b734c301" +
-        "ffffff00112233440000000002000c00" +
-        "44004f004d00410049004e0001000c00" +
-        "53004500520056004500520004001400" +
-        "64006f006d00610069006e002e006300" +
-        "6f006d00030022007300650072007600" +
-        "650072002e0064006f006d0061006900" +
-        "6e002e0063006f006d00000000000000" +
-        "0000"
-    ].pack("H*"))
+  describe '.ntlmv2_response' do
+    def target_info_blob
+      [
+        '02000c0044004f004d00410049004e00' \
+          '01000c00530045005200560045005200' \
+          '0400140064006f006d00610069006e00' \
+          '2e0063006f006d000300220073006500' \
+          '72007600650072002e0064006f006d00' \
+          '610069006e002e0063006f006d000000' \
+          '0000'
+      ].pack('H*')
+    end
+
+    def expected_ntlmv2_response
+      [
+        'cbabbca713eb795d04c97abc01ee498301010000000000000090d336b734c301' \
+          'ffffff00112233440000000002000c0044004f004d00410049004e0001000c00' \
+          '5300450052005600450052000400140064006f006d00610069006e002e006300' \
+          '6f006d00030022007300650072007600650072002e0064006f006d0061006900' \
+          '6e002e0063006f006d000000000000000000'
+      ].pack('H*')
+    end
+
+    it 'generates a ntlmv2_response' do
+      hash = described_class.ntlmv2_hash(user, passwd, domain)
+      args = { ntlmv2_hash: hash, challenge: challenge, target_info: target_info_blob }
+      opts = { timestamp: 1_055_844_000, client_challenge: client_ch }
+      expect(described_class.ntlmv2_response(args, opts)).to eq(expected_ntlmv2_response)
+    end
   end
 
-  it 'should generate a ntlm2_session' do
-    session = Net::NTLM::ntlm2_session(
-        {
-            :ntlm_hash => Net::NTLM::ntlm_hash(passwd),
-            :challenge => challenge
-        },
-        { :client_challenge => client_ch }
-    )
-    expect(session[0]).to eq(["ffffff001122334400000000000000000000000000000000"].pack("H*"))
-    expect(session[1]).to eq(["10d550832d12b2ccb79d5ad1f4eed3df82aca4c3681dd455"].pack("H*"))
+  describe '.ntlm2_session' do
+    def ntlm2_session_result
+      described_class.ntlm2_session(
+        { ntlm_hash: described_class.ntlm_hash(passwd), challenge: challenge },
+        { client_challenge: client_ch }
+      )
+    end
+
+    it 'generates the client challenge response' do
+      expect(ntlm2_session_result[0]).to eq(['ffffff001122334400000000000000000000000000000000'].pack('H*'))
+    end
+
+    it 'generates the session response' do
+      expect(ntlm2_session_result[1]).to eq(['10d550832d12b2ccb79d5ad1f4eed3df82aca4c3681dd455'].pack('H*'))
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Coverage must be started before the library under test is loaded, otherwise
 # methods defined at require time are not tracked.
 if ENV['COVERAGE']
@@ -14,7 +16,7 @@ require 'rspec'
 require 'net/ntlm'
 
 # Custom matchers, shared examples and other support code.
-Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each { |path| require path }
+Dir[File.expand_path('support/**/*.rb', __dir__)].sort.each do |path| require path end
 
 RSpec.configure do |config|
   # Require `RSpec.describe` rather than a top-level `describe`, so the gem's

--- a/spec/support/shared/examples/net/ntlm/field_shared.rb
+++ b/spec/support/shared/examples/net/ntlm/field_shared.rb
@@ -1,25 +1,24 @@
-RSpec.shared_examples_for 'a field' do  | value, active|
+# frozen_string_literal: true
 
+RSpec.shared_examples_for 'a field' do |value, active|
   subject do
     described_class.new({
-        :value  => value,
-        :active => active
+      value: value,
+      active: active
     })
   end
 
-  it { should respond_to :active }
-  it { should respond_to :value }
-  it { should respond_to :size }
-  it { should respond_to :parse }
-  it { should respond_to :serialize }
+  it { is_expected.to respond_to :active }
+  it { is_expected.to respond_to :value }
+  it { is_expected.to respond_to :size }
+  it { is_expected.to respond_to :parse }
+  it { is_expected.to respond_to :serialize }
 
-
-  it 'should set the value from initialize options' do
+  it 'sets the value from initialize options' do
     expect(subject.value).to eq(value)
   end
 
-  it 'should set active from initialize options' do
+  it 'sets active from initialize options' do
     expect(subject.active).to eq(active)
   end
-
 end

--- a/spec/support/shared/examples/net/ntlm/fieldset_shared.rb
+++ b/spec/support/shared/examples/net/ntlm/fieldset_shared.rb
@@ -1,39 +1,40 @@
-RSpec.shared_examples_for 'a fieldset' do |fields|
+# frozen_string_literal: true
 
+RSpec.shared_examples_for 'a fieldset' do |fields|
   subject(:fieldset_class) do
     Class.new(described_class)
   end
 
   context 'the class' do
-    it { should respond_to :string }
-    it { should respond_to :int16LE }
-    it { should respond_to :int32LE }
-    it { should respond_to :int64LE }
-    it { should respond_to :security_buffer }
-    it { should respond_to :prototypes }
-    it { should respond_to :names }
-    it { should respond_to :types }
-    it { should respond_to :opts }
+    it { is_expected.to respond_to :string }
+    it { is_expected.to respond_to :int16LE }
+    it { is_expected.to respond_to :int32LE }
+    it { is_expected.to respond_to :int64LE }
+    it { is_expected.to respond_to :security_buffer }
+    it { is_expected.to respond_to :prototypes }
+    it { is_expected.to respond_to :names }
+    it { is_expected.to respond_to :types }
+    it { is_expected.to respond_to :opts }
 
     context 'adding a String Field' do
-      before(:each) do
-        fieldset_class.string(:test_string, { :value => 'Test'})
+      before do
+        fieldset_class.string(:test_string, { value: 'Test' })
       end
 
-      it 'should set the prototypes correctly' do
-        expect(fieldset_class.prototypes).to include([:test_string, Net::NTLM::String, {:value=>"Test"}])
+      it 'sets the prototypes correctly' do
+        expect(fieldset_class.prototypes).to include([:test_string, Net::NTLM::String, { value: 'Test' }])
       end
 
-      it 'should set the names correctly' do
+      it 'sets the names correctly' do
         expect(fieldset_class.names).to include(:test_string)
       end
 
-      it 'should set the types correctly' do
+      it 'sets the types correctly' do
         expect(fieldset_class.types).to include(Net::NTLM::String)
       end
 
-      it 'should set the opts correctly' do
-        expect(fieldset_class.opts).to include({:value => 'Test'})
+      it 'sets the opts correctly' do
+        expect(fieldset_class.opts).to include({ value: 'Test' })
       end
 
       context 'when creating an instance' do
@@ -41,35 +42,35 @@ RSpec.shared_examples_for 'a fieldset' do |fields|
           fieldset_class.new
         end
 
-        it 'should have the new accessor' do
+        it 'has the new accessor' do
           expect(fieldset_object).to respond_to(:test_string)
         end
 
-        it 'should have the correct default value' do
+        it 'has the correct default value' do
           expect(fieldset_object.test_string).to eq('Test')
         end
       end
     end
 
     context 'adding a Int16LE Field' do
-      before(:each) do
-        fieldset_class.int16LE(:test_int, { :value => 15})
+      before do
+        fieldset_class.int16LE(:test_int, { value: 15 })
       end
 
-      it 'should set the prototypes correctly' do
-        expect(fieldset_class.prototypes).to include([:test_int, Net::NTLM::Int16LE, {:value=>15}])
+      it 'sets the prototypes correctly' do
+        expect(fieldset_class.prototypes).to include([:test_int, Net::NTLM::Int16LE, { value: 15 }])
       end
 
-      it 'should set the names correctly' do
+      it 'sets the names correctly' do
         expect(fieldset_class.names).to include(:test_int)
       end
 
-      it 'should set the types correctly' do
+      it 'sets the types correctly' do
         expect(fieldset_class.types).to include(Net::NTLM::Int16LE)
       end
 
-      it 'should set the opts correctly' do
-        expect(fieldset_class.opts).to include({:value => 15})
+      it 'sets the opts correctly' do
+        expect(fieldset_class.opts).to include({ value: 15 })
       end
 
       context 'when creating an instance' do
@@ -77,35 +78,35 @@ RSpec.shared_examples_for 'a fieldset' do |fields|
           fieldset_class.new
         end
 
-        it 'should have the new accessor' do
+        it 'has the new accessor' do
           expect(fieldset_object).to respond_to(:test_int)
         end
 
-        it 'should have the correct default value' do
+        it 'has the correct default value' do
           expect(fieldset_object.test_int).to eq(15)
         end
       end
     end
 
     context 'adding a Int32LE Field' do
-      before(:each) do
-        fieldset_class.int32LE(:test_int, { :value => 15})
+      before do
+        fieldset_class.int32LE(:test_int, { value: 15 })
       end
 
-      it 'should set the prototypes correctly' do
-        expect(fieldset_class.prototypes).to include([:test_int, Net::NTLM::Int32LE, {:value=>15}])
+      it 'sets the prototypes correctly' do
+        expect(fieldset_class.prototypes).to include([:test_int, Net::NTLM::Int32LE, { value: 15 }])
       end
 
-      it 'should set the names correctly' do
+      it 'sets the names correctly' do
         expect(fieldset_class.names).to include(:test_int)
       end
 
-      it 'should set the types correctly' do
+      it 'sets the types correctly' do
         expect(fieldset_class.types).to include(Net::NTLM::Int32LE)
       end
 
-      it 'should set the opts correctly' do
-        expect(fieldset_class.opts).to include({:value => 15})
+      it 'sets the opts correctly' do
+        expect(fieldset_class.opts).to include({ value: 15 })
       end
 
       context 'when creating an instance' do
@@ -113,35 +114,35 @@ RSpec.shared_examples_for 'a fieldset' do |fields|
           fieldset_class.new
         end
 
-        it 'should have the new accessor' do
+        it 'has the new accessor' do
           expect(fieldset_object).to respond_to(:test_int)
         end
 
-        it 'should have the correct default value' do
+        it 'has the correct default value' do
           expect(fieldset_object.test_int).to eq(15)
         end
       end
     end
 
     context 'adding a Int64LE Field' do
-      before(:each) do
-        fieldset_class.int64LE(:test_int, { :value => 15})
+      before do
+        fieldset_class.int64LE(:test_int, { value: 15 })
       end
 
-      it 'should set the prototypes correctly' do
-        expect(fieldset_class.prototypes).to include([:test_int, Net::NTLM::Int64LE, {:value=>15}])
+      it 'sets the prototypes correctly' do
+        expect(fieldset_class.prototypes).to include([:test_int, Net::NTLM::Int64LE, { value: 15 }])
       end
 
-      it 'should set the names correctly' do
+      it 'sets the names correctly' do
         expect(fieldset_class.names).to include(:test_int)
       end
 
-      it 'should set the types correctly' do
+      it 'sets the types correctly' do
         expect(fieldset_class.types).to include(Net::NTLM::Int64LE)
       end
 
-      it 'should set the opts correctly' do
-        expect(fieldset_class.opts).to include({:value => 15})
+      it 'sets the opts correctly' do
+        expect(fieldset_class.opts).to include({ value: 15 })
       end
 
       context 'when creating an instance' do
@@ -149,35 +150,35 @@ RSpec.shared_examples_for 'a fieldset' do |fields|
           fieldset_class.new
         end
 
-        it 'should have the new accessor' do
+        it 'has the new accessor' do
           expect(fieldset_object).to respond_to(:test_int)
         end
 
-        it 'should have the correct default value' do
+        it 'has the correct default value' do
           expect(fieldset_object.test_int).to eq(15)
         end
       end
     end
 
     context 'adding a SecurityBuffer Field' do
-      before(:each) do
-        fieldset_class.security_buffer(:test_buffer, { :value => 15})
+      before do
+        fieldset_class.security_buffer(:test_buffer, { value: 15 })
       end
 
-      it 'should set the prototypes correctly' do
-        expect(fieldset_class.prototypes).to include([:test_buffer, Net::NTLM::SecurityBuffer, {:value=>15}])
+      it 'sets the prototypes correctly' do
+        expect(fieldset_class.prototypes).to include([:test_buffer, Net::NTLM::SecurityBuffer, { value: 15 }])
       end
 
-      it 'should set the names correctly' do
+      it 'sets the names correctly' do
         expect(fieldset_class.names).to include(:test_buffer)
       end
 
-      it 'should set the types correctly' do
+      it 'sets the types correctly' do
         expect(fieldset_class.types).to include(Net::NTLM::SecurityBuffer)
       end
 
-      it 'should set the opts correctly' do
-        expect(fieldset_class.opts).to include({:value => 15})
+      it 'sets the opts correctly' do
+        expect(fieldset_class.opts).to include({ value: 15 })
       end
 
       context 'when creating an instance' do
@@ -185,55 +186,50 @@ RSpec.shared_examples_for 'a fieldset' do |fields|
           fieldset_class.new
         end
 
-        it 'should have the new accessor' do
+        it 'has the new accessor' do
           expect(fieldset_object).to respond_to :test_buffer
         end
 
-        it 'should have the correct default value' do
+        it 'has the correct default value' do
           expect(fieldset_object.test_buffer).to eq(15)
         end
       end
     end
-
   end
 
   context 'an instance' do
-
     subject(:fieldset_object) do
       # FieldSet Base Class and Message Base Class
       # have no fields by default and thus cannot be initialized
       # currently. Clumsy workaround for now.
-      if described_class.names.empty?
-        described_class.string(:test_string, { :value => 'Test', :active => true, :size => 4})
-      end
+      described_class.string(:test_string, { value: 'Test', active: true, size: 4 }) if described_class.names.empty?
       described_class.new
     end
 
-    it { should respond_to :serialize }
-    it { should respond_to :parse }
-    it { should respond_to :size }
-    it { should respond_to :enable }
-    it { should respond_to :disable }
+    it { is_expected.to respond_to :serialize }
+    it { is_expected.to respond_to :parse }
+    it { is_expected.to respond_to :size }
+    it { is_expected.to respond_to :enable }
+    it { is_expected.to respond_to :disable }
 
     context 'fields' do
       fields.each do |field|
-        it { should respond_to field[:name] }
+        it { is_expected.to respond_to field[:name] }
 
-        context "#{field[:name]}" do
-          it "should be a #{field[:class].to_s}" do
+        context field[:name].to_s do
+          it "is a #{field[:class]}" do
             expect(fieldset_object[field[:name]].class).to eq(field[:class])
           end
 
-          it "should have a default value of #{field[:value]}" do
+          it "has a default value of #{field[:value]}" do
             expect(fieldset_object[field[:name]].value).to eq(field[:value])
           end
 
-          it "should have active set to #{field[:active]}" do
+          it "has active set to #{field[:active]}" do
             expect(fieldset_object[field[:name]].active).to eq(field[:active])
           end
         end
       end
     end
-
   end
 end

--- a/spec/support/shared/examples/net/ntlm/int_shared.rb
+++ b/spec/support/shared/examples/net/ntlm/int_shared.rb
@@ -1,43 +1,49 @@
-RSpec.shared_examples_for 'an integer field' do  |values|
+# frozen_string_literal: true
 
+RSpec.shared_examples_for 'an integer field' do |values|
   subject do
     described_class.new({
-      :value => values[:default],
-      :active => true
+      value: values[:default],
+      active: true
     })
   end
 
-  context '#serialize' do
-    it 'should serialize properly with an integer value' do
+  describe '#serialize' do
+    it 'serializes properly with an integer value' do
       expect(subject.serialize).to eq(values[:default_hex])
     end
 
-    it 'should raise an Exception for a String' do
+    it 'raises an Exception for a String' do
       subject.value = 'A'
-      expect {subject.serialize}.to raise_error
+      expect { subject.serialize }.to raise_error(values[:error])
     end
 
-    it 'should raise an Exception for Nil' do
+    it 'raises an Exception for Nil' do
       subject.value = nil
-      expect {subject.serialize}.to raise_error
+      expect { subject.serialize }.to raise_error(values[:error])
     end
   end
 
-  context '#parse' do
-    it "should parse a raw #{values[:bits].to_s}-bit integer from a string" do
-      expect(subject.parse(values[:alt_hex])).to eq(values[:size])
-      expect(subject.value).to eq(values[:alt])
+  describe '#parse' do
+    it "parses a raw #{values[:bits]}-bit integer from a string" do
+      aggregate_failures do
+        expect(subject.parse(values[:alt_hex])).to eq(values[:size])
+        expect(subject.value).to eq(values[:alt])
+      end
     end
 
-    it "should use an offset to find the #{values[:bits].to_s}-bit integer in the string" do
-      expect(subject.parse("Value:#{values[:alt_hex]}",6)).to eq(values[:size])
-      expect(subject.value).to eq(values[:alt])
+    it "uses an offset to find the #{values[:bits]}-bit integer in the string" do
+      aggregate_failures do
+        expect(subject.parse("Value:#{values[:alt_hex]}", 6)).to eq(values[:size])
+        expect(subject.value).to eq(values[:alt])
+      end
     end
 
-    it 'should return 0 and not change the value if the string is not big enough' do
-      expect(subject.parse(values[:small])).to eq(0)
-      expect(subject.value).to eq(values[:default])
+    it 'returns 0 and not change the value if the string is not big enough' do
+      aggregate_failures do
+        expect(subject.parse(values[:small])).to eq(0)
+        expect(subject.value).to eq(values[:default])
+      end
     end
   end
-
 end

--- a/spec/support/shared/examples/net/ntlm/message_shared.rb
+++ b/spec/support/shared/examples/net/ntlm/message_shared.rb
@@ -1,35 +1,33 @@
-RSpec.shared_examples_for 'a message' do |flags|
+# frozen_string_literal: true
 
+RSpec.shared_examples_for 'a message' do |flags|
   subject(:test_message) do
     unless described_class.names.include?(:flag)
-      described_class.int32LE(:flag, {:value => Net::NTLM::DEFAULT_FLAGS[:TYPE1] })
+      described_class.int32LE(:flag, { value: Net::NTLM::DEFAULT_FLAGS[:TYPE1] })
     end
     described_class.new
   end
 
-  it { should respond_to :has_flag? }
-  it { should respond_to :set_flag }
-  it { should respond_to :dump_flags }
-  it { should respond_to :encode64 }
-  it { should respond_to :decode64 }
-  it { should respond_to :head_size }
-  it { should respond_to :data_size }
-  it { should respond_to :size }
-  it { should respond_to :security_buffers }
-  it { should respond_to :deflag }
-  it { should respond_to :data_edge }
+  it { is_expected.to respond_to :has_flag? }
+  it { is_expected.to respond_to :set_flag }
+  it { is_expected.to respond_to :dump_flags }
+  it { is_expected.to respond_to :encode64 }
+  it { is_expected.to respond_to :decode64 }
+  it { is_expected.to respond_to :head_size }
+  it { is_expected.to respond_to :data_size }
+  it { is_expected.to respond_to :size }
+  it { is_expected.to respond_to :security_buffers }
+  it { is_expected.to respond_to :deflag }
+  it { is_expected.to respond_to :data_edge }
 
   flags.each do |flag|
-    it "should be able to check if the #{flag} flag is set" do
+    it "is able to check if the #{flag} flag is set" do
       expect(test_message.has_flag?(flag)).to be(true)
     end
   end
 
-
-  it 'should be able to set a new flag' do
+  it 'is able to set a new flag' do
     test_message.set_flag(:DOMAIN_SUPPLIED)
     expect(test_message.has_flag?(:DOMAIN_SUPPLIED)).to be(true)
   end
-
-
 end


### PR DESCRIPTION
Resolves all 1,724 RuboCop offenses (53 files) and brings the repository to zero offenses.

- Safe-autocorrect and manual refactors across lib/ and spec/
- frozen_string_literal magic comments; fixed frozen-string regressions in channel bindings, TargetInfo serialization, and binary spec fixtures
- New snake_case APIs with legacy camelCase aliases kept for backward compatibility (int16_le/int16LE, disabled_fields?, flag?/has_flag?, flag=/set_flag, anonymous?, ntlm_hash?)
- Extracted response builders into lib/net/ntlm/response.rb and session crypto helpers into lib/net/ntlm/client/session_crypto.rb
- Refactored session authentication, MD4 fallback, parsing, RC4, TargetInfo parsing, channel bindings, and NTLMv2 derivation
- Reworked specs: split long examples, flattened nested groups, aggregate_failures and shared assertion helpers
- Full suite: 795 examples, 0 failures; RuboCop: 0 offenses
- required_ruby_version unchanged (>= 3.0.0)
- Removes continue-on-error and the advisory comments from the lint job so RuboCop failures now block the build